### PR TITLE
Refactor code format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ FOR_EACH_RANGE, FOR_EACH, ]
+IncludeCategories:
+  - Regex:           '^<.*\.h(pp)?>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 2000000
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...

--- a/include/ideep.hpp
+++ b/include/ideep.hpp
@@ -24,20 +24,20 @@
 #ifndef _IDEEP_HPP
 #define _IDEEP_HPP
 
-#include <cstdlib>
 #include <algorithm>
-#include <memory>
-#include <map>
-#include <vector>
-#include <iterator>
-#include <string>
+#include <cstdlib>
 #include <cstring>
-#include <numeric>
 #include <functional>
 #include <iostream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
 
 #include "ideep/abstract_types.hpp"
-#include "ideep/tensor.hpp"
 #include "ideep/computations.hpp"
+#include "ideep/tensor.hpp"
 
 #endif

--- a/include/ideep.hpp
+++ b/include/ideep.hpp
@@ -37,7 +37,7 @@
 #include <vector>
 
 #include "ideep/abstract_types.hpp"
-#include "ideep/computations.hpp"
 #include "ideep/tensor.hpp"
+#include "ideep/computations.hpp"
 
 #endif

--- a/include/ideep/abstract_types.hpp
+++ b/include/ideep/abstract_types.hpp
@@ -1,14 +1,14 @@
 #ifndef IDEEP_ABSTRACT_TYPES_HPP
 #define IDEEP_ABSTRACT_TYPES_HPP
 
-#include <string>
-#include <cstring>
-#include <map>
-#include <vector>
-#include <cstdlib>
-#include <functional>
 #include <dnnl.h>
 #include <dnnl.hpp>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
 #include "allocators.hpp"
 
 namespace ideep {
@@ -42,17 +42,17 @@ using exec_args = std::unordered_map<int, memory>;
 using key_t = std::string;
 
 #ifndef NDEBUG
-#define IDEEP_ENFORCE(condition, message) \
-  do {  \
-    error::wrap_c_api((condition) \
-        ? dnnl_success : dnnl_invalid_arguments, (message));  \
-  } while(false)
+#define IDEEP_ENFORCE(condition, message)                                \
+  do {                                                                   \
+    error::wrap_c_api(                                                   \
+        (condition) ? dnnl_success : dnnl_invalid_arguments, (message)); \
+  } while (false)
 #else
 #define IDEEP_ENFORCE(condition, message)
 #endif
 
-const scale_t IDEEP_DEF_SCALE {1.0f};
-const zero_point_t IDEEP_DEF_ZP {0};
+const scale_t IDEEP_DEF_SCALE{1.0f};
+const zero_point_t IDEEP_DEF_ZP{0};
 const scale_t IDEEP_EMPTY_SCALE;
 const zero_point_t IDEEP_EMPTY_ZP;
 
@@ -63,18 +63,14 @@ enum lowp_kind {
   LOWP_S8S8 = s8s8,
 };
 
-enum rnn_kind {
-  RNN_RELU = 0,
-  RNN_TANH = 1,
-  LSTM = 2,
-  GRU = 3
-};
+enum rnn_kind { RNN_RELU = 0, RNN_TANH = 1, LSTM = 2, GRU = 3 };
 
 static bool has_bf16_type_support() {
   // for v1.8
   // static bool support_bf16 = isa >= dnnl::cpu_isa::avx512_core
   //                           && isa != dnnl::cpu_isa::avx2_vnni;
-  static bool support_bf16 = dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx512_core;
+  static bool support_bf16 =
+      dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx512_core;
   return support_bf16;
 }
 
@@ -93,8 +89,9 @@ struct engine : public dnnl::engine {
         malloc(utils::allocator::malloc),
         free(utils::allocator::free) {}
 
-  void set_allocator(const std::function<void*(size_t)>& malloc,
-                     const std::function<void(void*)>& free) {
+  void set_allocator(
+      const std::function<void*(size_t)>& malloc,
+      const std::function<void(void*)>& free) {
     this->malloc = malloc;
     this->free = free;
   }
@@ -111,6 +108,6 @@ struct stream : public dnnl::stream {
     return s;
   }
 };
-}
+} // namespace ideep
 
 #endif

--- a/include/ideep/allocators.hpp
+++ b/include/ideep/allocators.hpp
@@ -7,7 +7,7 @@ namespace ideep {
 namespace utils {
 
 class allocator {
-public:
+ public:
   constexpr static size_t tensor_memalignment = 4096;
 
   static char* malloc(size_t size) {
@@ -30,6 +30,6 @@ public:
   }
 };
 
-}
-}
+} // namespace utils
+} // namespace ideep
 #endif

--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -12,14 +12,18 @@ using post_ops = dnnl::post_ops;
 struct attr_t : public dnnl::primitive_attr {
   attr_t() {}
 
-  attr_t(int mask, const scale_t& scales) { set_output_scales(mask, scales); }
+  attr_t(int mask, const scale_t& scales) {
+    set_output_scales(mask, scales);
+  }
 
   std::pair<scale_t, int> get_output_scales() const {
     dnnl_dim_t count;
     int c_mask;
     const float* c_scales;
-    error::wrap_c_api(dnnl_primitive_attr_get_output_scales(
-        get(), &count, &c_mask, &c_scales), "could not get int output scales");
+    error::wrap_c_api(
+        dnnl_primitive_attr_get_output_scales(
+            get(), &count, &c_mask, &c_scales),
+        "could not get int output scales");
     return std::make_pair(scale_t(c_scales, c_scales + count), c_mask);
   }
 
@@ -32,8 +36,10 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_relu(float scale = 1.0, float alpha = 0.f,
-                          float beta = 0.f) {
+  static attr_t fuse_relu(
+      float scale = 1.0,
+      float alpha = 0.f,
+      float beta = 0.f) {
     attr_t attr;
     post_ops po;
     po.append_eltwise(scale, algorithm::eltwise_relu, alpha, beta);
@@ -41,9 +47,11 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_gelu(float scale = 1.0, float alpha = 0.f,
-                          float beta = 0.f,
-                          algorithm gelu_type = algorithm::eltwise_gelu_erf) {
+  static attr_t fuse_gelu(
+      float scale = 1.0,
+      float alpha = 0.f,
+      float beta = 0.f,
+      algorithm gelu_type = algorithm::eltwise_gelu_erf) {
     attr_t attr;
     post_ops po;
     po.append_eltwise(scale, gelu_type, alpha, beta);
@@ -51,8 +59,10 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_elu(float scale = 1.0, float alpha = 0.f,
-                         float beta = 1.0) {
+  static attr_t fuse_elu(
+      float scale = 1.0,
+      float alpha = 0.f,
+      float beta = 1.0) {
     attr_t attr;
     post_ops po;
     po.append_eltwise(scale, algorithm::eltwise_elu, alpha, beta);
@@ -60,8 +70,10 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_sigmoid(float scale = 1.0, float alpha = 1.0,
-                             float beta = 0.f) {
+  static attr_t fuse_sigmoid(
+      float scale = 1.0,
+      float alpha = 1.0,
+      float beta = 0.f) {
     attr_t attr;
     post_ops po;
     po.append_eltwise(scale, algorithm::eltwise_logistic, alpha, beta);
@@ -69,8 +81,10 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_swish(float scale = 1.0, float alpha = 1.0,
-                           float beta = 0.f) {
+  static attr_t fuse_swish(
+      float scale = 1.0,
+      float alpha = 1.0,
+      float beta = 0.f) {
     attr_t attr;
     post_ops po;
     po.append_eltwise(scale, algorithm::eltwise_swish, alpha, beta);
@@ -78,8 +92,10 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_tanh(float scale = 1.0, float alpha = 0.f,
-                          float beta = 0.f) {
+  static attr_t fuse_tanh(
+      float scale = 1.0,
+      float alpha = 0.f,
+      float beta = 0.f) {
     attr_t attr;
     post_ops po;
     po.append_eltwise(scale, algorithm::eltwise_tanh, alpha, beta);
@@ -87,8 +103,10 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_mish(float scale = 1.0, float alpha = 1.0,
-                          float beta = 0.f) {
+  static attr_t fuse_mish(
+      float scale = 1.0,
+      float alpha = 1.0,
+      float beta = 0.f) {
     attr_t attr;
     post_ops po;
     po.append_eltwise(scale, algorithm::eltwise_mish, alpha, beta);
@@ -96,8 +114,11 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t residual(float sum_scale = 1.0, float relu_scale = 1.0,
-                         float alpha = 0.f, float beta = 0.f) {
+  static attr_t residual(
+      float sum_scale = 1.0,
+      float relu_scale = 1.0,
+      float alpha = 0.f,
+      float beta = 0.f) {
     attr_t attr;
     post_ops po;
     po.append_sum(sum_scale);
@@ -182,13 +203,13 @@ struct attr_t : public dnnl::primitive_attr {
   void to_bytes(utils::bytestring& bytes) const {
     // encode post ops
     auto num_ops = get_post_ops().len();
-    for (int i = 0; i < num_ops; i ++) {
+    for (int i = 0; i < num_ops; i++) {
       kind akind;
       algorithm alg = algorithm::undef;
       float scale = 1.0, alpha = 1.0, beta = 0.0;
       std::tie(akind, scale, alpha, beta, alg) = get_params(i);
 
-      switch(akind) {
+      switch (akind) {
         case kind::sum:
           utils::to_bytes(bytes, akind);
           bytes.append(1, '.');
@@ -224,6 +245,6 @@ struct attr_t : public dnnl::primitive_attr {
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/lru_cache.hpp
+++ b/include/ideep/lru_cache.hpp
@@ -8,9 +8,12 @@
 namespace ideep {
 namespace utils {
 
-template <class key_t, class value_t, template <typename ...> class map = std::unordered_map>
+template <
+    class key_t,
+    class value_t,
+    template <typename...> class map = std::unordered_map>
 class lru_cache {
-public:
+ public:
   class node_t;
 
   typedef typename std::pair<key_t, value_t> value_type;
@@ -22,25 +25,31 @@ public:
 
   // Only class possible, we can't use typedef or using. Or can we?
   class node_t : public std::pair<map_it, value_t> {
-  public:
-    node_t (const std::pair<map_it, value_t>& l) : std::pair<map_it, value_t>(l) {}
-    node_t (std::pair<map_it, value_t>&& l) : std::pair<map_it, value_t>(std::move(l)) {}
+   public:
+    node_t(const std::pair<map_it, value_t>& l)
+        : std::pair<map_it, value_t>(l) {}
+    node_t(std::pair<map_it, value_t>&& l)
+        : std::pair<map_it, value_t>(std::move(l)) {}
   };
 
   typedef typename std::list<node_t>::size_type size_type;
 
   lru_cache(size_type capacity) : capacity_(capacity) {}
 
-  size_type size() const { map_.size(); }
+  size_type size() const {
+    map_.size();
+  }
 
-  size_type max_size() const { return capacity_; }
+  size_type max_size() const {
+    return capacity_;
+  }
 
   void resize(size_type new_capacity) {
     capacity_ = new_capacity;
     // Trim cache
     while (map_.size() > capacity_) {
       auto last = vlist_.end();
-      last --;
+      last--;
       map_.erase(last->first);
       vlist_.pop_back();
     }
@@ -114,7 +123,7 @@ public:
     // Trim cache
     while (map_.size() > capacity_) {
       auto last = vlist_.end();
-      last --;
+      last--;
       map_.erase(last->first);
       vlist_.pop_back();
     }
@@ -134,7 +143,7 @@ public:
     std::swap(capacity_, other.capacity_);
   }
 
-private:
+ private:
   std::list<node_t> vlist_;
   map<key_t, iterator> map_;
   size_type capacity_;
@@ -142,10 +151,10 @@ private:
 
 template <class value_t, size_t capacity = 1024, class key_t = std::string>
 class computation_cache {
-public:
+ public:
   using iterator = typename lru_cache<key_t, value_t>::iterator;
 
-protected:
+ protected:
   template <typename T>
   static inline iterator create(const key_t& key, T&& args) {
     auto it = t_store().insert(std::make_pair(key, std::forward<T>(args)));
@@ -168,9 +177,10 @@ protected:
     return t_store().end();
   }
 
-public:
- static inline value_t& fetch_or_create(
-     const key_t& key, const std::function<value_t()>& callback) {
+ public:
+  static inline value_t& fetch_or_create(
+      const key_t& key,
+      const std::function<value_t()>& callback) {
     auto it = find(key);
     return it == end() ? fetch(create((key), callback())) : fetch(it);
   }
@@ -181,18 +191,19 @@ public:
 
   static inline lru_cache<key_t, value_t>& t_store() {
     static thread_local lru_cache<key_t, value_t> t_store_(capacity);
-    static thread_local int new_capacity = [&](const char *pt) {
+    static thread_local int new_capacity = [&](const char* pt) {
       if (pt != NULL) {
-        IDEEP_ENFORCE(std::atoi(pt) > 0 , "The LRU_CACHE_CAPACITY should be positive");
+        IDEEP_ENFORCE(
+            std::atoi(pt) > 0, "The LRU_CACHE_CAPACITY should be positive");
         t_store_.resize(std::atoi(pt));
         return std::atoi(pt);
       } else {
         return 0;
       }
-    } (std::getenv("LRU_CACHE_CAPACITY"));
+    }(std::getenv("LRU_CACHE_CAPACITY"));
     return t_store_;
   }
 };
-}
-}
+} // namespace utils
+} // namespace ideep
 #endif

--- a/include/ideep/operators/batchnorm.hpp
+++ b/include/ideep/operators/batchnorm.hpp
@@ -6,44 +6,49 @@ namespace ideep {
 
 struct batch_normalization_forward_inference
     : public dnnl::batch_normalization_forward {
-
   using super = dnnl::batch_normalization_forward;
 
-  static void compute(const tensor& src,
-                      const tensor& scale,
-                      const tensor& shift,
-                      tensor& dst,
-                      float epsilon,
-                      const batch_normalization_flag flags = batch_normalization_flag::use_scale_shift,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& scale,
+      const tensor& shift,
+      tensor& dst,
+      float epsilon,
+      const batch_normalization_flag flags =
+          batch_normalization_flag::use_scale_shift,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy;
     compute_impl</*use_stats=*/false>(
         src, dummy, dummy, scale, shift, dst, epsilon, flags, aengine);
   }
 
-  static void compute(const tensor& src,
-                      const tensor& mean,
-                      const tensor& variance,
-                      const tensor& scale,
-                      const tensor& shift,
-                      tensor& dst,
-                      float epsilon,
-                      const batch_normalization_flag flags = batch_normalization_flag::use_scale_shift,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& mean,
+      const tensor& variance,
+      const tensor& scale,
+      const tensor& shift,
+      tensor& dst,
+      float epsilon,
+      const batch_normalization_flag flags =
+          batch_normalization_flag::use_scale_shift,
+      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*use_stats=*/true>(
         src, mean, variance, scale, shift, dst, epsilon, flags, aengine);
   }
+
  private:
   template <bool use_stats>
-  static void compute_impl(const tensor& src,
-                           const tensor& mean,
-                           const tensor& variance,
-                           const tensor& scale,
-                           const tensor& shift,
-                           tensor& dst,
-                           float epsilon,
-                           const batch_normalization_flag flags,
-                           const engine& aengine) {
+  static void compute_impl(
+      const tensor& src,
+      const tensor& mean,
+      const tensor& variance,
+      const tensor& scale,
+      const tensor& shift,
+      tensor& dst,
+      float epsilon,
+      const batch_normalization_flag flags,
+      const engine& aengine) {
     auto pd_flags = batch_normalization_flag::use_scale_shift;
     if (use_stats)
       pd_flags |= batch_normalization_flag::use_global_stats;
@@ -52,58 +57,67 @@ struct batch_normalization_forward_inference
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
     // auto src_desc = src.get_desc();
 
-    bool fuse_norm_relu = (bool) (flags & batch_normalization_flag::fuse_norm_relu);
+    bool fuse_norm_relu =
+        (bool)(flags & batch_normalization_flag::fuse_norm_relu);
     attr_t attr = fuse_norm_relu ? attr_t::fuse_relu() : attr_t();
     attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto pd = primitive_desc(
-        {prop_kind::forward_inference, src_desc, epsilon, pd_flags}, attr, aengine);
+        {prop_kind::forward_inference, src_desc, epsilon, pd_flags},
+        attr,
+        aengine);
 
-    tensor scale_shift {pd.weights_desc()};
+    tensor scale_shift{pd.weights_desc()};
     tensor scratchpad(pd.scratchpad_desc());
-    auto* scale_shift_buf = static_cast<char *>(scale_shift.get_data_handle());
+    auto* scale_shift_buf = static_cast<char*>(scale_shift.get_data_handle());
     std::memcpy(scale_shift_buf, scale.get_data_handle(), scale.get_size());
-    std::memcpy(scale_shift_buf + scale.get_size(),
-                shift.get_data_handle(), shift.get_size());
+    std::memcpy(
+        scale_shift_buf + scale.get_size(),
+        shift.get_data_handle(),
+        shift.get_size());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     dst.reinit_if_possible(pd.dst_desc());
 
     if (use_stats) {
       auto expected_mean = mean.reorder_if_differ_in(pd.mean_desc());
       auto expected_var = variance.reorder_if_differ_in(pd.variance_desc());
-      super(pd).execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_SCALE_SHIFT, scale_shift},
-                         {DNNL_ARG_VARIANCE, expected_var},
-                         {DNNL_ARG_MEAN, expected_mean},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_SCALE_SHIFT, scale_shift},
+           {DNNL_ARG_VARIANCE, expected_var},
+           {DNNL_ARG_MEAN, expected_mean},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      super(pd).execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_SCALE_SHIFT, scale_shift},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_SCALE_SHIFT, scale_shift},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
 };
 
 struct batch_normalization_forward_training
     : public dnnl::batch_normalization_forward {
-
   using super = dnnl::batch_normalization_forward;
 
-  static void compute(const tensor& src,
-                      const tensor& scale,
-                      const tensor& shift,
-                      tensor& dst,
-                      tensor& mean,
-                      tensor& variance,
-                      float momentum,
-                      float epsilon,
-                      const batch_normalization_flag flags = batch_normalization_flag::use_scale_shift,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& scale,
+      const tensor& shift,
+      tensor& dst,
+      tensor& mean,
+      tensor& variance,
+      float momentum,
+      float epsilon,
+      const batch_normalization_flag flags =
+          batch_normalization_flag::use_scale_shift,
+      const engine& aengine = engine::cpu_engine()) {
     auto pd_flags = flags | batch_normalization_flag::use_scale_shift;
-    bool with_workspace = (bool) (flags & batch_normalization_flag::fuse_norm_relu);
+    bool with_workspace =
+        (bool)(flags & batch_normalization_flag::fuse_norm_relu);
 
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
@@ -117,23 +131,26 @@ struct batch_normalization_forward_training
         op_attr,
         aengine);
 
-    tensor scale_shift {pd.weights_desc()};
+    tensor scale_shift{pd.weights_desc()};
     tensor scratchpad(pd.scratchpad_desc());
-    auto* scale_shift_buf = static_cast<char *>(scale_shift.get_data_handle());
+    auto* scale_shift_buf = static_cast<char*>(scale_shift.get_data_handle());
     std::memcpy(scale_shift_buf, scale.get_data_handle(), scale.get_size());
-    std::memcpy(scale_shift_buf + scale.get_size(),
-                shift.get_data_handle(), shift.get_size());
+    std::memcpy(
+        scale_shift_buf + scale.get_size(),
+        shift.get_data_handle(),
+        shift.get_size());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     mean.reinit_if_possible(pd.mean_desc());
     variance.reinit_if_possible(pd.variance_desc());
     dst.reinit_if_possible(pd.dst_desc());
 
-    exec_args args {{DNNL_ARG_SRC, expected_src},
-                    {DNNL_ARG_SCALE_SHIFT, scale_shift},
-                    {DNNL_ARG_MEAN, mean},
-                    {DNNL_ARG_VARIANCE, variance},
-                    {DNNL_ARG_DST, dst},
-                    {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{
+        {DNNL_ARG_SRC, expected_src},
+        {DNNL_ARG_SCALE_SHIFT, scale_shift},
+        {DNNL_ARG_MEAN, mean},
+        {DNNL_ARG_VARIANCE, variance},
+        {DNNL_ARG_DST, dst},
+        {DNNL_ARG_SCRATCHPAD, scratchpad}};
     if (with_workspace) {
       dst.init_workspace(pd.workspace_desc());
       args.insert({DNNL_ARG_WORKSPACE, dst.get_workspace()});
@@ -141,44 +158,48 @@ struct batch_normalization_forward_training
     super(pd).execute(stream::default_stream(), args);
   }
 
-  static void compute(const tensor& src,
-                      const tensor& scale,
-                      const tensor& shift,
-                      tensor& dst,
-                      tensor& mean,
-                      tensor& variance,
-                      tensor& running_mean,
-                      tensor& running_var,
-                      float momentum,
-                      float epsilon,
-                      const batch_normalization_flag flags = batch_normalization_flag::use_scale_shift) {
-   compute(src, scale, shift, dst, mean, variance, momentum, epsilon, flags);
-   ideep::sum::compute({momentum, 1 - momentum}, {running_mean, mean},
-                       running_mean);
-   ideep::sum::compute({momentum, 1 - momentum}, {running_var, variance},
-                       running_var);
+  static void compute(
+      const tensor& src,
+      const tensor& scale,
+      const tensor& shift,
+      tensor& dst,
+      tensor& mean,
+      tensor& variance,
+      tensor& running_mean,
+      tensor& running_var,
+      float momentum,
+      float epsilon,
+      const batch_normalization_flag flags =
+          batch_normalization_flag::use_scale_shift) {
+    compute(src, scale, shift, dst, mean, variance, momentum, epsilon, flags);
+    ideep::sum::compute(
+        {momentum, 1 - momentum}, {running_mean, mean}, running_mean);
+    ideep::sum::compute(
+        {momentum, 1 - momentum}, {running_var, variance}, running_var);
   }
 };
 
 struct batch_normalization_backward
     : public dnnl::batch_normalization_backward {
-
   using super = dnnl::batch_normalization_backward;
 
-  static void compute(const tensor& src,
-                      const tensor& mean,
-                      const tensor& variance,
-                      const tensor& diff_dst,
-                      const tensor& scale,
-                      tensor& diff_src,
-                      tensor& diff_scale_shift,
-                      float epsilon,
-                      const tensor& dst = tensor(),
-                      const batch_normalization_flag flags = batch_normalization_flag::use_scale_shift,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& mean,
+      const tensor& variance,
+      const tensor& diff_dst,
+      const tensor& scale,
+      tensor& diff_src,
+      tensor& diff_scale_shift,
+      float epsilon,
+      const tensor& dst = tensor(),
+      const batch_normalization_flag flags =
+          batch_normalization_flag::use_scale_shift,
+      const engine& aengine = engine::cpu_engine()) {
     // TODO: support no-affine model
     auto pd_flags = flags | batch_normalization_flag::use_scale_shift;
-    bool with_workspace = (bool) (flags & batch_normalization_flag::fuse_norm_relu);
+    bool with_workspace =
+        (bool)(flags & batch_normalization_flag::fuse_norm_relu);
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
     // auto src_desc = src.get_desc();
@@ -189,8 +210,14 @@ struct batch_normalization_backward
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {prop_kind::backward, forward_hints.dst_desc(), src_desc, epsilon, pd_flags},
-        op_attr, aengine, forward_hints);
+        {prop_kind::backward,
+         forward_hints.dst_desc(),
+         src_desc,
+         epsilon,
+         pd_flags},
+        op_attr,
+        aengine,
+        forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
@@ -201,47 +228,63 @@ struct batch_normalization_backward
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {{DNNL_ARG_SRC, expected_src},
-                    {DNNL_ARG_DIFF_DST, expected_diff_dst},
-                    {DNNL_ARG_SCALE_SHIFT, scale}, // only need scale
-                    {DNNL_ARG_MEAN, expected_mean},
-                    {DNNL_ARG_VARIANCE, expected_variance},
-                    {DNNL_ARG_DIFF_SRC, diff_src},
-                    {DNNL_ARG_DIFF_SCALE_SHIFT, diff_scale_shift},
-                    {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{
+        {DNNL_ARG_SRC, expected_src},
+        {DNNL_ARG_DIFF_DST, expected_diff_dst},
+        {DNNL_ARG_SCALE_SHIFT, scale}, // only need scale
+        {DNNL_ARG_MEAN, expected_mean},
+        {DNNL_ARG_VARIANCE, expected_variance},
+        {DNNL_ARG_DIFF_SRC, diff_src},
+        {DNNL_ARG_DIFF_SCALE_SHIFT, diff_scale_shift},
+        {DNNL_ARG_SCRATCHPAD, scratchpad}};
     if (with_workspace) {
       args.insert({DNNL_ARG_WORKSPACE, dst.get_workspace()});
     }
-    super(pd).execute(stream::default_stream(), args);   
+    super(pd).execute(stream::default_stream(), args);
   }
 
-  static void compute(const tensor& src,
-                      const tensor& mean,
-                      const tensor& variance,
-                      const tensor& diff_dst,
-                      const tensor& scale,
-                      tensor& diff_src,
-                      tensor& diff_scale,
-                      tensor& diff_shift,
-                      float epsilon,
-                      const tensor& dst = tensor(),
-                      const batch_normalization_flag flags = batch_normalization_flag::use_scale_shift,
-                      const engine& aengine = engine::cpu_engine()) {
-  tensor diff_scale_shift;
-  compute(src, mean, variance, diff_dst, scale, diff_src, diff_scale_shift,
-          epsilon, dst, flags, aengine);
-  diff_scale.reinit_if_possible(scale.get_desc());
-  diff_shift.reinit_if_possible(scale.get_desc());
-  auto* diff_scale_shift_buf =
-      static_cast<char*>(diff_scale_shift.get_data_handle());
-  std::memcpy(diff_scale.get_data_handle(), diff_scale_shift_buf,
-              diff_scale.get_size());
-  std::memcpy(diff_shift.get_data_handle(),
-              diff_scale_shift_buf + diff_scale.get_size(),
-              diff_shift.get_size());
+  static void compute(
+      const tensor& src,
+      const tensor& mean,
+      const tensor& variance,
+      const tensor& diff_dst,
+      const tensor& scale,
+      tensor& diff_src,
+      tensor& diff_scale,
+      tensor& diff_shift,
+      float epsilon,
+      const tensor& dst = tensor(),
+      const batch_normalization_flag flags =
+          batch_normalization_flag::use_scale_shift,
+      const engine& aengine = engine::cpu_engine()) {
+    tensor diff_scale_shift;
+    compute(
+        src,
+        mean,
+        variance,
+        diff_dst,
+        scale,
+        diff_src,
+        diff_scale_shift,
+        epsilon,
+        dst,
+        flags,
+        aengine);
+    diff_scale.reinit_if_possible(scale.get_desc());
+    diff_shift.reinit_if_possible(scale.get_desc());
+    auto* diff_scale_shift_buf =
+        static_cast<char*>(diff_scale_shift.get_data_handle());
+    std::memcpy(
+        diff_scale.get_data_handle(),
+        diff_scale_shift_buf,
+        diff_scale.get_size());
+    std::memcpy(
+        diff_shift.get_data_handle(),
+        diff_scale_shift_buf + diff_scale.get_size(),
+        diff_shift.get_size());
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/binary.hpp
+++ b/include/ideep/operators/binary.hpp
@@ -4,14 +4,14 @@
 namespace ideep {
 
 struct binary : public dnnl::binary {
-
   using super = dnnl::binary;
 
-  static void compute(const tensor& src0,
-                      const tensor& src1,
-                      tensor& dst,
-                      algorithm aalgorithm,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src0,
+      const tensor& src1,
+      tensor& dst,
+      algorithm aalgorithm,
+      const engine& aengine = engine::cpu_engine()) {
     auto src0_desc = src0.get_desc();
     auto src1_desc = src1.get_desc();
     auto dst_desc = src0_desc.to_format_any();
@@ -28,14 +28,15 @@ struct binary : public dnnl::binary {
     auto expected_src1 = src1.reorder_if_differ_in(pd.src1_desc());
     dst.reinit_if_possible(pd.dst_desc());
 
-    super(pd).execute(stream::default_stream(),
-                      {{DNNL_ARG_SRC_0, expected_src0},
-                       {DNNL_ARG_SRC_1, expected_src1},
-                       {DNNL_ARG_DST, dst},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC_0, expected_src0},
+         {DNNL_ARG_SRC_1, expected_src1},
+         {DNNL_ARG_DST, dst},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/channel_shuffle.hpp
+++ b/include/ideep/operators/channel_shuffle.hpp
@@ -3,16 +3,16 @@
 
 namespace ideep {
 
-struct channel_shuffle_forward: public dnnl::shuffle_forward {
-
+struct channel_shuffle_forward : public dnnl::shuffle_forward {
   using super = dnnl::shuffle_forward;
 
-  static void compute(const tensor& src,
-                      tensor& dst,
-                      const int group,
-                      const int axis = 1,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      tensor& dst,
+      const int group,
+      const int axis = 1,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     IDEEP_ENFORCE(src.get_dim(axis) % group == 0, "Invalid channel and group");
     IDEEP_ENFORCE(src.get_data_type() == data_type::f32, "invalid data type");
 
@@ -21,30 +21,31 @@ struct channel_shuffle_forward: public dnnl::shuffle_forward {
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    auto pd =
-        primitive_desc({aprop_kind, src.get_desc(), axis, group_size}, aengine, op_attr);
+    auto pd = primitive_desc(
+        {aprop_kind, src.get_desc(), axis, group_size}, aengine, op_attr);
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     dst.reinit_if_possible(pd.dst_desc());
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(),
-                      {{DNNL_ARG_SRC, expected_src},
-                       {DNNL_ARG_DST, dst},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC, expected_src},
+         {DNNL_ARG_DST, dst},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
 struct channel_shuffle_backward : public dnnl::shuffle_backward {
-
   using super = dnnl::shuffle_backward;
 
-  static void compute(const tensor& diff_dst,
-                      tensor& diff_src,
-                      const int group,
-                      const int axis = 1,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& diff_dst,
+      tensor& diff_src,
+      const int group,
+      const int axis = 1,
+      const engine& aengine = engine::cpu_engine()) {
     auto group_size = static_cast<int>(diff_dst.get_dim(axis) / group);
     auto data_desc = diff_dst.get_desc();
 
@@ -62,13 +63,14 @@ struct channel_shuffle_backward : public dnnl::shuffle_backward {
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(),
-                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                       {DNNL_ARG_DIFF_SRC, diff_src},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+         {DNNL_ARG_DIFF_SRC, diff_src},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/concat.hpp
+++ b/include/ideep/operators/concat.hpp
@@ -4,13 +4,13 @@
 namespace ideep {
 
 struct concat : public dnnl::concat {
-
   using super = dnnl::concat;
 
-  static void compute(const std::vector<tensor>& inputs,
-                      int axis,
-                      tensor& output,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const std::vector<tensor>& inputs,
+      int axis,
+      tensor& output,
+      const engine& aengine = engine::cpu_engine()) {
     auto input_descs = utils::fmap(inputs, [](const tensor& t) {
       // "upcast" vector<tensor::desc> to vector<memory::desc>
       return static_cast<memory::desc>(t.get_desc());
@@ -29,8 +29,8 @@ struct concat : public dnnl::concat {
     //   (Very fast) Works only when all memories are in the same format
     //   (Slower) Generic one, based on reorders: concat of n tensors is a set
     //            of n reorders from input to the proper part of the output
-    // In case you have only two inputs there should not be performance 
-    // difference between reordering one input to the format of the other one 
+    // In case you have only two inputs there should not be performance
+    // difference between reordering one input to the format of the other one
     // and emit the fast concat implementation versus using generic concat which
     // emits two reorders. So we align all tensors to the same optimial format
     // only when there are more than two inputs.
@@ -50,7 +50,7 @@ struct concat : public dnnl::concat {
     }
 
     tensor scratchpad(pd.scratchpad_desc());
-    exec_args args {{DNNL_ARG_DST, output}, {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{{DNNL_ARG_DST, output}, {DNNL_ARG_SCRATCHPAD, scratchpad}};
 
     for (int i = 0; i < opt_inputs.size(); ++i) {
       args.insert({DNNL_ARG_MULTIPLE_SRC + i, opt_inputs[i]});
@@ -66,13 +66,15 @@ struct concat : public dnnl::concat {
       bool add_axis,
       tensor& dst,
       const engine& aengine = engine::cpu_engine()) {
-    IDEEP_ENFORCE(axis < (inputs[0].ndims() + add_axis),
-                  "invalid axis in concat");
+    IDEEP_ENFORCE(
+        axis < (inputs[0].ndims() + add_axis), "invalid axis in concat");
     for (int i = 0; i < inputs[0].ndims(); i++) {
-      if (i == axis && !add_axis) continue;
+      if (i == axis && !add_axis)
+        continue;
       for (unsigned j = 1; j < inputs.size(); j++) {
-        IDEEP_ENFORCE(inputs[j].get_dim(i) == inputs[0].get_dim(i),
-                      "invalid input dims in concat");
+        IDEEP_ENFORCE(
+            inputs[j].get_dim(i) == inputs[0].get_dim(i),
+            "invalid input dims in concat");
       }
     }
 
@@ -115,7 +117,7 @@ struct concat : public dnnl::concat {
       auto dst_desc = inputs[0].get_desc().to_dims(dst_dims);
       dst.reinit_if_possible(dst_desc);
     }
-      
+
     if (utils::one_of(dst_data_type, data_type::s8, data_type::u8))
       dst.set_scale(min_scale);
 
@@ -160,6 +162,6 @@ struct concat : public dnnl::concat {
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -11,167 +11,284 @@ struct deconv_forward_params {
 };
 
 struct convolution_transpose_forward : public dnnl::deconvolution_forward {
-
   using super = dnnl::deconvolution_forward;
 
   // With bias. Zero points are passed explicitly as arguments for quantization
   // Bias is not used if it is empty.
-  static void compute_v2(const tensor& src,
-                         const tensor& weights, // dim: {o, i[, d], h, w}
-                         const tensor& bias,
-                         const dims& dst_dims,
-                         tensor& dst,
-                         const dims& strides,
-                         const dims& padding_l,
-                         const dims& padding_r,
-                         const dims& dilates = {1, 1},
-                         int groups = 1,
-                         const scale_t& src_scales = scale_t(),
-                         const scale_t& weights_scales = scale_t(),
-                         const scale_t& dst_scales = scale_t(),
-                         const zero_point_t& src_zero_point = zero_point_t(),
-                         const zero_point_t& dst_zero_point = zero_point_t(),
-                         const attr_t& attr = attr_t(),
-                         algorithm aalgorithm = algorithm::deconvolution_direct,
-                         prop_kind aprop_kind = prop_kind::forward,
-                         const lowp_kind alowp_kind = u8s8,
-                         const engine& aengine = engine::cpu_engine()) {
+  static void compute_v2(
+      const tensor& src,
+      const tensor& weights, // dim: {o, i[, d], h, w}
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      int groups = 1,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const zero_point_t& src_zero_point = zero_point_t(),
+      const zero_point_t& dst_zero_point = zero_point_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     } else {
       compute_impl</*with_bias=*/true>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     }
   }
 
-  // Without bias. Zero points are passed explicitly as arguments for quantization
-  static void compute_v2(const tensor& src,
-                         const tensor& weights, // dim: {o, i[, d], h, w}
-                         const dims& dst_dims,
-                         tensor& dst,
-                         const dims& strides,
-                         const dims& padding_l,
-                         const dims& padding_r,
-                         const dims& dilates = {1, 1},
-                         int groups = 1,
-                         const scale_t& src_scales = scale_t(),
-                         const scale_t& weights_scales = scale_t(),
-                         const scale_t& dst_scales = scale_t(),
-                         const zero_point_t& src_zero_point = zero_point_t(),
-                         const zero_point_t& dst_zero_point = zero_point_t(),
-                         const attr_t& attr = attr_t(),
-                         algorithm aalgorithm = algorithm::deconvolution_direct,
-                         prop_kind aprop_kind = prop_kind::forward,
-                         const lowp_kind alowp_kind = u8s8,
-                         const engine& aengine = engine::cpu_engine()) {
+  // Without bias. Zero points are passed explicitly as arguments for
+  // quantization
+  static void compute_v2(
+      const tensor& src,
+      const tensor& weights, // dim: {o, i[, d], h, w}
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      int groups = 1,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const zero_point_t& src_zero_point = zero_point_t(),
+      const zero_point_t& dst_zero_point = zero_point_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_impl</*with_bias=*/false>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // Deprecated. With bias. Zero points are set to tensor for quantization.
-  static void compute(const tensor& src,
-                      const tensor& weights, // dim: {o, i[, d], h, w}
-                      const tensor& bias,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      int groups = 1,
-                      const scale_t& src_scales = scale_t(),
-                      const scale_t& weights_scales = scale_t(),
-                      const scale_t& dst_scales = scale_t(),
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights, // dim: {o, i[, d], h, w}
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      int groups = 1,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*with_bias=*/true>(
-        src, weights, bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        zero_point_t(),
+        zero_point_t(),
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // Deprecated. Without bias. Zero points are set to tensor for quantization.
-  static void compute(const tensor& src,
-                      const tensor& weights, // dim: {o, i[, d], h, w}
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      int groups = 1,
-                      const scale_t& src_scales = scale_t(),
-                      const scale_t& weights_scales = scale_t(),
-                      const scale_t& dst_scales = scale_t(),
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights, // dim: {o, i[, d], h, w}
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      int groups = 1,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_impl</*with_bias=*/false>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        zero_point_t(),
+        zero_point_t(),
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // Bias is not used if it is empty.
-  static void prepare(deconv_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights, // dim: {o, i[, d], h, w}
-                      const tensor& bias,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      int groups = 1,
-                      const scale_t& src_scales = scale_t(),
-                      const scale_t& weights_scales = scale_t(),
-                      const scale_t& dst_scales = scale_t(),
-                      const zero_point_t& src_zero_point = zero_point_t(),
-                      const zero_point_t& dst_zero_point = zero_point_t(),
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      deconv_forward_params& param,
+      const tensor& src,
+      const tensor& weights, // dim: {o, i[, d], h, w}
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      int groups = 1,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const zero_point_t& src_zero_point = zero_point_t(),
+      const zero_point_t& dst_zero_point = zero_point_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     bool with_bias = (!bias.is_empty());
-    do_prepare(param, src, weights, bias, with_bias, dst_dims, dst,
-               strides, dilates, padding_l, padding_r, groups,
-               src_scales, weights_scales, dst_scales,
-               src_zero_point, dst_zero_point, attr,
-               aalgorithm, aprop_kind, alowp_kind, aengine);
+    do_prepare(
+        param,
+        src,
+        weights,
+        bias,
+        with_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // Bias is not used if it is empty.
-  static void compute(const super::primitive_desc& pd,
-                      const super& primitive,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& expected_bias,
-                      tensor& dst,
-                      const tensor& src_zero_point,
-                      int groups) {
+  static void compute(
+      const super::primitive_desc& pd,
+      const super& primitive,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& expected_bias,
+      tensor& dst,
+      const tensor& src_zero_point,
+      int groups) {
     bool with_bias = (!expected_bias.is_empty());
-    do_compute(pd, primitive, src, weights, expected_bias,
-               with_bias, dst, src_zero_point, groups);
+    do_compute(
+        pd,
+        primitive,
+        src,
+        weights,
+        expected_bias,
+        with_bias,
+        dst,
+        src_zero_point,
+        groups);
   }
 
   static tensor::desc expected_weights_desc(
-      const dims& weights_dims,   // [i, o, ...]
+      const dims& weights_dims, // [i, o, ...]
       data_type dtype = data_type::f32,
       const dims& strides = {1, 1},
       const dims& padding_l = {0, 0},
@@ -183,8 +300,8 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const dims& src_dims = dims(),
       const attr_t& attr = attr_t(),
       const engine& aengine = engine::cpu_engine()) {
-
-    auto src_size = weights_dims.size(); // weights_dims is 4 for conv2d and 5 for conv3d
+    auto src_size =
+        weights_dims.size(); // weights_dims is 4 for conv2d and 5 for conv3d
     auto grouped = groups > 1;
     auto weights_dims_g =
         grouped ? utils::group_dims(weights_dims, groups) : weights_dims;
@@ -212,8 +329,12 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       y_dims.push_back(1);
       y_dims.push_back(oc);
       auto valid_x_dim = [=](int idx) {
-          return std::max((padding_l[idx] + padding_r[idx] - (1 + (kernel_size[idx] - 1) * dilates[idx])) / strides[idx] + 2,
-                          2 * kernel_size[idx]);
+        return std::max(
+            (padding_l[idx] + padding_r[idx] -
+             (1 + (kernel_size[idx] - 1) * dilates[idx])) /
+                    strides[idx] +
+                2,
+            2 * kernel_size[idx]);
       };
       if (4 == src_size) {
         x_dims.push_back(valid_x_dim(0));
@@ -225,14 +346,16 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       }
     } else {
       // Use the real data
-      for (auto i=0; i < src_size; ++i) {
+      for (auto i = 0; i < src_size; ++i) {
         x_dims.push_back(src_dims[i]);
       }
       y_dims.push_back(src_dims[0]);
       y_dims.push_back(oc);
     }
     for (auto d = 2; d < src_size; ++d) {
-      auto out_size = (x_dims[d] - 1) * strides[d-2] + (1 + (kernel_size[d-2] - 1) * (dilates[d-2])) - padding_l[d-2] - padding_r[d-2];
+      auto out_size = (x_dims[d] - 1) * strides[d - 2] +
+          (1 + (kernel_size[d - 2] - 1) * (dilates[d - 2])) - padding_l[d - 2] -
+          padding_r[d - 2];
       y_dims.push_back(out_size);
     }
     auto x_dtype = (dtype != data_type::s8) ? dtype : data_type::u8;
@@ -242,8 +365,17 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     tensor::desc dst_desc(y_dims, y_dtype);
 
     auto pd = get_primitive_desc</*with_bias=*/false>(
-        src_desc, weights_desc, tensor::desc(), dst_desc, strides, dilates_,
-        padding_l, padding_r, attr, aalgorithm, aprop_kind);
+        src_desc,
+        weights_desc,
+        tensor::desc(),
+        dst_desc,
+        strides,
+        dilates_,
+        padding_l,
+        padding_r,
+        attr,
+        aalgorithm,
+        aprop_kind);
 
     // embed group info into weights_desc
     if (grouped) {
@@ -252,7 +384,7 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     } else {
       // [o, i, ...] -> [i, o, ...]
       return tensor::desc(pd.weights_desc(), groups).transpose(0, 1);
-    } 
+    }
   }
 
   template <bool with_bias>
@@ -276,44 +408,63 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     auto format_tag = is_nhwc ? tag::nhwc : (is_ndhwc ? tag::ndhwc : tag::any);
     auto src_desc_query = src_desc.to_format(format_tag);
     auto weights_desc_query = weights_desc.to_format_any();
-    auto bias_desc_query = with_bias ? bias_desc.to_format_any() : tensor::desc();
+    auto bias_desc_query =
+        with_bias ? bias_desc.to_format_any() : tensor::desc();
     auto dst_desc_query = dst_desc.to_format(format_tag);
 
     if (with_bias) {
-      return primitive_desc({aprop_kind, aalgorithm, src_desc_query,
-                             weights_desc_query, bias_desc_query, dst_desc_query,
-                             strides, dilates, padding_l, padding_r},
-                            attr, aengine);
+      return primitive_desc(
+          {aprop_kind,
+           aalgorithm,
+           src_desc_query,
+           weights_desc_query,
+           bias_desc_query,
+           dst_desc_query,
+           strides,
+           dilates,
+           padding_l,
+           padding_r},
+          attr,
+          aengine);
     } else {
-      return primitive_desc({aprop_kind, aalgorithm, src_desc_query,
-                             weights_desc_query, dst_desc_query,
-                             strides, dilates, padding_l, padding_r},
-                            attr, aengine);
+      return primitive_desc(
+          {aprop_kind,
+           aalgorithm,
+           src_desc_query,
+           weights_desc_query,
+           dst_desc_query,
+           strides,
+           dilates,
+           padding_l,
+           padding_r},
+          attr,
+          aengine);
     }
   }
 
  private:
   template <bool with_bias>
-  static void compute_impl(const tensor& src,
-                           const tensor& weights,
-                           const tensor& bias,
-                           const dims& dst_dims,
-                           tensor& dst,
-                           const dims& strides,
-                           const dims& dilates,
-                           const dims& padding_l,
-                           const dims& padding_r,
-                           int groups,
-                           const scale_t& src_scales,
-                           const scale_t& weights_scales,
-                           const scale_t& dst_scales,
-                           const zero_point_t& src_zero_point,
-                           const zero_point_t& dst_zero_point,
-                           const attr_t& attr,
-                           algorithm aalgorithm,
-                           prop_kind aprop_kind,
-                           const lowp_kind alowp_kind,
-                           const engine& aengine) {
+  static void compute_impl(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_point,
+      const zero_point_t& dst_zero_point,
+      const attr_t& attr,
+      algorithm aalgorithm,
+      prop_kind aprop_kind,
+      const lowp_kind alowp_kind,
+      const engine& aengine) {
     scale_t dst_scales_in;
     data_type dst_data_type;
     tensor::desc src_desc, weights_desc, bias_desc, dst_desc;
@@ -322,67 +473,101 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src, weights, bias, dst_dims, dst, dilates, groups,
-        src_scales, weights_scales, dst_scales, src_zero_point, dst_zero_point,
-        attr, alowp_kind, with_bias, true,
-        weights_grouped, dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
-        src_desc, weights_desc, bias_desc, dst_desc);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        dilates,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        alowp_kind,
+        with_bias,
+        true,
+        weights_grouped,
+        dil_compatible,
+        op_attr,
+        src_attr,
+        weights_attr,
+        bias_attr,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc);
 
     auto pd = get_primitive_desc<with_bias>(
-        src_desc, weights_desc, bias_desc, dst_desc,
-        strides, dil_compatible, padding_l, padding_r, op_attr, aalgorithm,
-        aprop_kind, aengine);
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        strides,
+        dil_compatible,
+        padding_l,
+        padding_r,
+        op_attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
 
     tensor scratchpad(pd.scratchpad_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
-    auto expected_weights = weights_grouped.reorder_if_differ_in(pd.weights_desc());
+    auto expected_weights =
+        weights_grouped.reorder_if_differ_in(pd.weights_desc());
     dst.reinit_if_possible(pd.dst_desc());
 
     tensor src_zero_point_m;
-    conv_deconv_utils::obtain_runtime_zero_point(src, src_zero_point, DNNL_ARG_SRC,
-                                                 op_attr, aengine, src_zero_point_m);
+    conv_deconv_utils::obtain_runtime_zero_point(
+        src, src_zero_point, DNNL_ARG_SRC, op_attr, aengine, src_zero_point_m);
 
     if (with_bias) {
       auto expected_bias = bias.reorder_if_differ_in(pd.bias_desc(), bias_attr);
-      super(pd).execute(stream::default_stream(), 
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_BIAS, expected_bias},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_BIAS, expected_bias},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      super(pd).execute(stream::default_stream(), 
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
 
-  static void do_prepare(deconv_forward_params& param,
-                         const tensor& src,
-                         const tensor& weights,
-                         const tensor& bias,
-                         bool with_bias,
-                         const dims& dst_dims,
-                         tensor& dst,
-                         const dims& strides,
-                         const dims& dilates,
-                         const dims& padding_l,
-                         const dims& padding_r,
-                         int groups,
-                         const scale_t& src_scales,
-                         const scale_t& weights_scales,
-                         const scale_t& dst_scales,
-                         const zero_point_t& src_zero_point,
-                         const zero_point_t& dst_zero_point,
-                         const attr_t& attr,
-                         algorithm aalgorithm,
-                         prop_kind aprop_kind,
-                         const lowp_kind alowp_kind,
-                         const engine& aengine) {
+  static void do_prepare(
+      deconv_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      bool with_bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_point,
+      const zero_point_t& dst_zero_point,
+      const attr_t& attr,
+      algorithm aalgorithm,
+      prop_kind aprop_kind,
+      const lowp_kind alowp_kind,
+      const engine& aengine) {
     scale_t dst_scales_in;
     data_type dst_data_type;
     tensor::desc src_desc, weights_desc, bias_desc, dst_desc;
@@ -391,82 +576,123 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src, weights, bias, dst_dims, dst, dilates, groups,
-        src_scales, weights_scales, dst_scales, src_zero_point, dst_zero_point,
-        attr, alowp_kind, with_bias, true,
-        weights_grouped, dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
-        src_desc, weights_desc, bias_desc, dst_desc);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        dilates,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        alowp_kind,
+        with_bias,
+        true,
+        weights_grouped,
+        dil_compatible,
+        op_attr,
+        src_attr,
+        weights_attr,
+        bias_attr,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc);
 
-    auto pd = with_bias ?
-              get_primitive_desc</*with_bias=*/true>(
-                  src_desc, weights_desc, bias_desc, dst_desc,
-                  strides, dil_compatible, padding_l, padding_r, op_attr, aalgorithm,
-                  aprop_kind, aengine) :
-              get_primitive_desc</*with_bias=*/false>(
-                  src_desc, weights_desc, bias_desc, dst_desc,
-                  strides, dil_compatible, padding_l, padding_r, op_attr, aalgorithm,
-                  aprop_kind, aengine);
+    auto pd = with_bias ? get_primitive_desc</*with_bias=*/true>(
+                              src_desc,
+                              weights_desc,
+                              bias_desc,
+                              dst_desc,
+                              strides,
+                              dil_compatible,
+                              padding_l,
+                              padding_r,
+                              op_attr,
+                              aalgorithm,
+                              aprop_kind,
+                              aengine)
+                        : get_primitive_desc</*with_bias=*/false>(
+                              src_desc,
+                              weights_desc,
+                              bias_desc,
+                              dst_desc,
+                              strides,
+                              dil_compatible,
+                              padding_l,
+                              padding_r,
+                              op_attr,
+                              aalgorithm,
+                              aprop_kind,
+                              aengine);
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
-    auto expected_weights = weights_grouped.reorder_if_differ_in(pd.weights_desc());
+    auto expected_weights =
+        weights_grouped.reorder_if_differ_in(pd.weights_desc());
     dst.reinit_if_possible(pd.dst_desc());
 
     tensor src_zero_point_m;
-    conv_deconv_utils::obtain_runtime_zero_point(src, src_zero_point, DNNL_ARG_SRC,
-                                                 op_attr, aengine, src_zero_point_m);
+    conv_deconv_utils::obtain_runtime_zero_point(
+        src, src_zero_point, DNNL_ARG_SRC, op_attr, aengine, src_zero_point_m);
     param.pd = std::move(pd);
     param.bias_attr = bias_attr;
     param.input_zero_point = std::move(src_zero_point_m);
     param.groups = groups;
   }
 
-  static void do_compute(const super::primitive_desc& pd,
-                         const super& primitive,
-                         const tensor& src,
-                         const tensor& weights,
-                         const tensor& expected_bias,
-                         bool with_bias,
-                         tensor& dst,
-                         const tensor& src_zero_point,
-                         int groups) {
+  static void do_compute(
+      const super::primitive_desc& pd,
+      const super& primitive,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& expected_bias,
+      bool with_bias,
+      tensor& dst,
+      const tensor& src_zero_point,
+      int groups) {
     tensor scratchpad(pd.scratchpad_desc());
     auto expected_weights = weights.make_grouped_weights(groups);
     if (with_bias) {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_BIAS, expected_bias},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_BIAS, expected_bias},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
-
 };
 
 struct convolution_transpose_backward_data
     : public dnnl::deconvolution_backward_data {
-
   using super = dnnl::deconvolution_backward_data;
 
-  static void compute(const tensor& diff_dst,
-                      const tensor& weights, // dim: {i, o[, d], h, w}
-                      const dims& diff_src_dims,
-                      tensor& diff_src,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      const int groups = 1,
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& diff_dst,
+      const tensor& weights, // dim: {i, o[, d], h, w}
+      const dims& diff_src_dims,
+      tensor& diff_src,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      const int groups = 1,
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups, true);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -477,91 +703,130 @@ struct convolution_transpose_backward_data
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
     auto weights_desc = weights_.get_desc().to_format_any();
 
-    tensor::desc diff_src_desc(diff_src_dims, diff_dst_desc.get_data_type(), format_tag);
+    tensor::desc diff_src_desc(
+        diff_src_dims, diff_dst_desc.get_data_type(), format_tag);
 
     auto forward_hints =
         convolution_transpose_forward::get_primitive_desc</*with_bias=*/false>(
-            diff_src_desc, weights_desc, tensor::desc(), diff_dst_desc, strides,
-            dilates_, padding_l, padding_r);
+            diff_src_desc,
+            weights_desc,
+            tensor::desc(),
+            diff_dst_desc,
+            strides,
+            dilates_,
+            padding_l,
+            padding_r);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
-         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
+        {aalgorithm,
+         diff_src_desc,
+         weights_desc,
+         diff_dst_desc,
+         strides,
+         dilates_,
+         padding_l,
+         padding_r},
+        op_attr,
+        aengine,
+        forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(), 
-                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                       {DNNL_ARG_WEIGHTS, expected_weights},
-                       {DNNL_ARG_DIFF_SRC, diff_src},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+         {DNNL_ARG_WEIGHTS, expected_weights},
+         {DNNL_ARG_DIFF_SRC, diff_src},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
 struct convolution_transpose_backward_weights
     : public dnnl::deconvolution_backward_weights {
-
   using super = dnnl::deconvolution_backward_weights;
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      const dims& diff_weights_dims,
-                      tensor& diff_weights,
-                      tensor& diff_bias,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      const int groups = 1,
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
-   compute_impl</*with_diff_bias=*/true>(
-       src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
-       strides, dilates, padding_l, padding_r, groups, aalgorithm, aengine);
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims,
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      const int groups = 1,
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
+    compute_impl</*with_diff_bias=*/true>(
+        src,
+        diff_dst,
+        diff_weights_dims,
+        diff_weights,
+        diff_bias,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        aalgorithm,
+        aengine);
   }
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      const dims& diff_weights_dims,
-                      tensor& diff_weights,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      const int groups = 1,
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims,
+      tensor& diff_weights,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      const int groups = 1,
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
-        src, diff_dst, diff_weights_dims, diff_weights, dummy_diff_bias,
-        strides, dilates, padding_l, padding_r, groups, aalgorithm, aengine);
+        src,
+        diff_dst,
+        diff_weights_dims,
+        diff_weights,
+        dummy_diff_bias,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        aalgorithm,
+        aengine);
   }
-private:
-  template <bool with_diff_bias>
-  static void compute_impl(const tensor& src,
-                           const tensor& diff_dst,
-                           const dims& diff_weights_dims, // [i, o, ...]
-                           tensor& diff_weights,
-                           tensor& diff_bias,
-                           const dims& strides,
-                           const dims& dilates,
-                           const dims& padding_l,
-                           const dims& padding_r,
-                           const int groups,
-                           algorithm aalgorithm,
-                           const engine& aengine) {
 
+ private:
+  template <bool with_diff_bias>
+  static void compute_impl(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims, // [i, o, ...]
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      const int groups,
+      algorithm aalgorithm,
+      const engine& aengine) {
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
 
     // dim: [i, o, ...]
-    auto diff_weights_desc = 
+    auto diff_weights_desc =
         tensor::desc(diff_weights_dims, diff_dst.get_data_type(), tag::any);
 
     if (groups > 1) {
@@ -585,20 +850,47 @@ private:
 
     auto forward_hints =
         convolution_transpose_forward::get_primitive_desc<with_diff_bias>(
-            src_desc, diff_weights_desc, diff_bias_desc, diff_dst_desc, strides,
-            dilates_, padding_l, padding_r, attr_t(), aalgorithm,
-            prop_kind::forward, aengine);
+            src_desc,
+            diff_weights_desc,
+            diff_bias_desc,
+            diff_dst_desc,
+            strides,
+            dilates_,
+            padding_l,
+            padding_r,
+            attr_t(),
+            aalgorithm,
+            prop_kind::forward,
+            aengine);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    auto pd = with_diff_bias
-        ? primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_bias_desc, diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints)
-        : primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints);
+    auto pd = with_diff_bias ? primitive_desc(
+                                   {aalgorithm,
+                                    src_desc,
+                                    diff_weights_desc,
+                                    diff_bias_desc,
+                                    diff_dst_desc,
+                                    strides,
+                                    dilates_,
+                                    padding_l,
+                                    padding_r},
+                                   op_attr,
+                                   aengine,
+                                   forward_hints)
+                             : primitive_desc(
+                                   {aalgorithm,
+                                    src_desc,
+                                    diff_weights_desc,
+                                    diff_dst_desc,
+                                    strides,
+                                    dilates_,
+                                    padding_l,
+                                    padding_r},
+                                   op_attr,
+                                   aengine,
+                                   forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
@@ -610,18 +902,20 @@ private:
 
     if (with_diff_bias) {
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
-      super(pd).execute(stream::default_stream(),
-                        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                         {DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_DIFF_WEIGHTS, diff_weights},
-                         {DNNL_ARG_DIFF_BIAS, diff_bias},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+           {DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_DIFF_WEIGHTS, diff_weights},
+           {DNNL_ARG_DIFF_BIAS, diff_bias},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      super(pd).execute(stream::default_stream(),
-                        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                         {DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_DIFF_WEIGHTS, diff_weights},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+           {DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_DIFF_WEIGHTS, diff_weights},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
 
     // recover output dims to align with pytorch
@@ -634,6 +928,6 @@ private:
     }
   }
 };
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/direct_copy.hpp
+++ b/include/ideep/operators/direct_copy.hpp
@@ -13,6 +13,6 @@ struct direct_copy {
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/dropout.hpp
+++ b/include/ideep/operators/dropout.hpp
@@ -4,8 +4,11 @@
 namespace ideep {
 
 struct dropout_forward {
-  static void compute(const tensor& src, float ratio, tensor& dst,
-                      tensor& mask) {
+  static void compute(
+      const tensor& src,
+      float ratio,
+      tensor& dst,
+      tensor& mask) {
     switch (src.get_data_type()) {
       case data_type::f32:
         compute_impl<float>(src, ratio, dst, mask);
@@ -26,8 +29,11 @@ struct dropout_forward {
 
  private:
   template <typename T>
-  static void compute_impl(const tensor& src, float ratio, tensor& dst,
-                           tensor& mask) {
+  static void compute_impl(
+      const tensor& src,
+      float ratio,
+      tensor& dst,
+      tensor& mask) {
     mask.reinit_if_possible(src.get_desc());
     dst.reinit_if_possible(src.get_desc());
     if (src.has_scale()) {
@@ -44,9 +50,9 @@ struct dropout_forward {
     const auto dst_data = static_cast<T*>(dst.get_data_handle());
 #ifdef _OPENMP
 #if (_OPENMP >= 201307)
-# pragma omp parallel for simd
+#pragma omp parallel for simd
 #else
-# pragma omp parallel for schedule(static)
+#pragma omp parallel for schedule(static)
 #endif
 #endif
     for (auto i = 0; i < size; i++) {
@@ -57,8 +63,10 @@ struct dropout_forward {
 };
 
 struct dropout_backward {
-  static void compute(const tensor& mask, const tensor& diff_dst,
-                      tensor& diff_src) {
+  static void compute(
+      const tensor& mask,
+      const tensor& diff_dst,
+      tensor& diff_src) {
     switch (diff_dst.get_data_type()) {
       case data_type::f32:
         compute_impl<float>(mask, diff_dst, diff_src);
@@ -79,8 +87,10 @@ struct dropout_backward {
 
  private:
   template <typename T>
-  static void compute_impl(const tensor& mask, const tensor& diff_dst,
-                           tensor& diff_src) {
+  static void compute_impl(
+      const tensor& mask,
+      const tensor& diff_dst,
+      tensor& diff_src) {
     diff_src.reinit_if_possible(diff_dst.get_desc());
 
     const auto size = mask.get_size() / sizeof(T);
@@ -96,6 +106,6 @@ struct dropout_backward {
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -4,16 +4,16 @@
 namespace ideep {
 
 struct eltwise_forward : public dnnl::eltwise_forward {
-
   using super = dnnl::eltwise_forward;
 
-  static void compute(const tensor& src,
-                      tensor& dst,
-                      algorithm aalgorithm = algorithm::eltwise_relu,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      float alpha = 0.0,
-                      float beta = 0.0,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      tensor& dst,
+      algorithm aalgorithm = algorithm::eltwise_relu,
+      prop_kind aprop_kind = prop_kind::forward,
+      float alpha = 0.0,
+      float beta = 0.0,
+      const engine& aengine = engine::cpu_engine()) {
     auto src_in = src;
     // we should leave dequantization to the framework
     if (aalgorithm != algorithm::eltwise_relu &&
@@ -34,10 +34,11 @@ struct eltwise_forward : public dnnl::eltwise_forward {
     }
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(),
-                      {{DNNL_ARG_SRC, src_in},
-                       {DNNL_ARG_DST, dst},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC, src_in},
+         {DNNL_ARG_DST, dst},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
 
     // xpz: ???
     if (dst.has_scale() && aalgorithm == algorithm::eltwise_relu &&
@@ -51,46 +52,51 @@ struct eltwise_backward : public dnnl::eltwise_backward {
   using super = dnnl::eltwise_backward;
   // If grady and x had different format, performance is bad.
   // TODO: Seeking a single shot solution.
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      tensor& diff_src,
-                      algorithm aalgorithm = algorithm::eltwise_relu,
-                      float alpha = 0.0,
-                      float beta = 0.0,
-                      const engine& aengine = engine::cpu_engine()) {
-  auto src_desc = src.get_desc();
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      tensor& diff_src,
+      algorithm aalgorithm = algorithm::eltwise_relu,
+      float alpha = 0.0,
+      float beta = 0.0,
+      const engine& aengine = engine::cpu_engine()) {
+    auto src_desc = src.get_desc();
 
-  auto forward_hints = eltwise_forward::primitive_desc(
-      {prop_kind::forward, aalgorithm, src_desc, alpha, beta}, aengine);
+    auto forward_hints = eltwise_forward::primitive_desc(
+        {prop_kind::forward, aalgorithm, src_desc, alpha, beta}, aengine);
 
-  auto op_attr = dnnl::primitive_attr();
-  op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    auto op_attr = dnnl::primitive_attr();
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-  auto pd =
-      primitive_desc({aalgorithm, forward_hints.dst_desc(), src_desc, alpha, beta},
-                     op_attr, aengine, forward_hints);
+    auto pd = primitive_desc(
+        {aalgorithm, forward_hints.dst_desc(), src_desc, alpha, beta},
+        op_attr,
+        aengine,
+        forward_hints);
 
-  auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
-  auto expected_src = src.reorder_if_differ_in(pd.src_desc());
-  diff_src.reinit_if_possible(pd.diff_src_desc());
+    auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
+    auto expected_src = src.reorder_if_differ_in(pd.src_desc());
+    diff_src.reinit_if_possible(pd.diff_src_desc());
 
-  auto use_dst = utils::one_of(aalgorithm,
-                               algorithm::eltwise_relu_use_dst_for_bwd,
-                               algorithm::eltwise_tanh_use_dst_for_bwd,
-                               algorithm::eltwise_elu_use_dst_for_bwd,
-                               algorithm::eltwise_sqrt_use_dst_for_bwd,
-                               algorithm::eltwise_logistic_use_dst_for_bwd,
-                               algorithm::eltwise_exp_use_dst_for_bwd);
-  auto src_dst_arg = use_dst ? DNNL_ARG_DST : DNNL_ARG_SRC;
+    auto use_dst = utils::one_of(
+        aalgorithm,
+        algorithm::eltwise_relu_use_dst_for_bwd,
+        algorithm::eltwise_tanh_use_dst_for_bwd,
+        algorithm::eltwise_elu_use_dst_for_bwd,
+        algorithm::eltwise_sqrt_use_dst_for_bwd,
+        algorithm::eltwise_logistic_use_dst_for_bwd,
+        algorithm::eltwise_exp_use_dst_for_bwd);
+    auto src_dst_arg = use_dst ? DNNL_ARG_DST : DNNL_ARG_SRC;
 
-  tensor scratchpad(pd.scratchpad_desc());
-  super(pd).execute(stream::default_stream(),
-                    {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                    {src_dst_arg, expected_src},
-                    {DNNL_ARG_DIFF_SRC, diff_src},
-                    {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    tensor scratchpad(pd.scratchpad_desc());
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+         {src_dst_arg, expected_src},
+         {DNNL_ARG_DIFF_SRC, diff_src},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/gru.hpp
+++ b/include/ideep/operators/gru.hpp
@@ -4,15 +4,13 @@
 namespace ideep {
 
 struct gru_forward : public dnnl::gru_forward {
-  static void compute() {
-  }
+  static void compute() {}
 };
 
 struct gru_backward : public dnnl::gru_backward {
-  static void compute() {
-  }
+  static void compute() {}
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -38,69 +38,75 @@ struct inner_product_forward
   using super = dnnl::inner_product_forward;
 
   // 2-in-1 compute, with bias
-  static void compute(const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst,
-                      const attr_t& attr = attr_t(),
-                      const prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
-    compute_impl</*with_bias=*/true>(src, weights, bias, dst, attr,
-                                     aprop_kind, aengine);
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
+    compute_impl</*with_bias=*/true>(
+        src, weights, bias, dst, attr, aprop_kind, aengine);
   }
 
   // 2-in-1 compute, without bias
-  static void compute(const tensor& src,
-                      const tensor& weights,
-                      tensor& dst,
-                      const attr_t& attr = attr_t(),
-                      const prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst, attr,
-                                      aprop_kind, aengine);
+    compute_impl</*with_bias=*/false>(
+        src, weights, dummy_bias, dst, attr, aprop_kind, aengine);
   }
 
   // Prepare with bias
-  static void prepare(inner_product_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst,
-                      const attr_t& attr = attr_t(),
-                      const prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
-    do_prepare</*with_bias=*/true>(param, src, weights, bias, dst, attr,
-                                   aprop_kind, aengine);
+  static void prepare(
+      inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
+    do_prepare</*with_bias=*/true>(
+        param, src, weights, bias, dst, attr, aprop_kind, aengine);
   }
 
   // Prepare without bias
-  static void prepare(inner_product_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      tensor& dst,
-                      const attr_t& attr = attr_t(),
-                      const prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    do_prepare</*with_bias=*/false>(param, src, weights, dummy_bias, dst, attr,
-                                   aprop_kind, aengine);
+    do_prepare</*with_bias=*/false>(
+        param, src, weights, dummy_bias, dst, attr, aprop_kind, aengine);
   }
 
   // Compute with prepared param, with bias
-  static void compute(const inner_product_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst) {
+  static void compute(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     do_compute</*with_bias=*/true>(param, src, weights, bias, dst);
   }
 
   // Compute with prepared param, without bias
-  static void compute(const inner_product_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      tensor& dst) {
+  static void compute(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst) {
     static tensor dummy_bias;
     do_compute</*with_bias=*/false>(param, src, weights, dummy_bias, dst);
   }
@@ -118,8 +124,9 @@ struct inner_product_forward
     auto ndims = weights_dims.size();
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 
-    IDEEP_ENFORCE(x_dims.size() == weights_dims.size(),
-                  "Invalid dims for data and weights");
+    IDEEP_ENFORCE(
+        x_dims.size() == weights_dims.size(),
+        "Invalid dims for data and weights");
     tensor::desc src_desc(x_dims, x_dtype, tag::any);
     tensor::desc dst_desc(y_dims, y_dtype, tag::any);
     tensor::desc weights_desc(weights_dims, dtype, tag::any);
@@ -159,15 +166,16 @@ struct inner_product_forward
     });
   };
 
-private:
+ private:
   template <bool with_bias>
-  static void compute_impl(const tensor& src,
-                           const tensor& weights,
-                           const tensor& bias,
-                           tensor& dst,
-                           const attr_t& attr,
-                           const prop_kind aprop_kind,
-                           const engine& aengine) {
+  static void compute_impl(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr,
+      const prop_kind aprop_kind,
+      const engine& aengine) {
     inner_product_forward_params param;
     // workaround: src and weights from caffe2 may have different dims.
     // It would be better for caffe2 to do this reshape anyway.
@@ -176,24 +184,27 @@ private:
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
-      do_prepare_<with_bias>(param, src_, weights, bias, dst, attr, aprop_kind, aengine);
+      do_prepare_<with_bias>(
+          param, src_, weights, bias, dst, attr, aprop_kind, aengine);
       do_compute_<with_bias>(param, src_, weights, bias, dst);
     } else {
-      do_prepare_<with_bias>(param, src, weights, bias, dst, attr, aprop_kind, aengine);
+      do_prepare_<with_bias>(
+          param, src, weights, bias, dst, attr, aprop_kind, aengine);
       do_compute_<with_bias>(param, src, weights, bias, dst);
     }
     // compute_impl_<with_bias>(src_, weights, bias, dst, attr,
-                             // aprop_kind, aengine);
+    // aprop_kind, aengine);
   }
 
   template <bool with_bias>
-  static void compute_impl_(const tensor& src,
-                            const tensor& weights,
-                            const tensor& bias,
-                            tensor& dst,
-                            const attr_t& attr,
-                            const prop_kind aprop_kind,
-                            const engine& aengine) {
+  static void compute_impl_(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr,
+      const prop_kind aprop_kind,
+      const engine& aengine) {
     tensor::desc src_desc, weights_desc, bias_desc;
     attr_t op_attr, src_attr, weights_attr, bias_attr;
     scale_t dst_scales_in;
@@ -207,9 +218,9 @@ private:
       src_attr = {0, src_scale};
     }
 
-    IDEEP_ENFORCE(utils::one_of(weights.get_data_type(),
-                                data_type::f32, data_type::bf16),
-            "Incorrect data type in weights");
+    IDEEP_ENFORCE(
+        utils::one_of(weights.get_data_type(), data_type::f32, data_type::bf16),
+        "Incorrect data type in weights");
 
     // align weights data type with src
     dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
@@ -217,9 +228,9 @@ private:
     src_desc = {src.get_dims(), dst_data_type, format_tag::any};
     weights_desc = {weights.get_dims(), dst_data_type, format_tag::any};
     if (with_bias) {
-      IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
-                                  data_type::f32, data_type::bf16),
-                    "Incorrect data type in bias");
+      IDEEP_ENFORCE(
+          utils::one_of(bias.get_data_type(), data_type::f32, data_type::bf16),
+          "Incorrect data type in bias");
       bias_desc = bias.get_desc().to_format_any();
     }
 
@@ -237,13 +248,15 @@ private:
         aprop_kind);
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc(), src_attr);
-    auto expected_weights = weights.reorder_if_differ_in(pd.weights_desc(), weights_attr);
+    auto expected_weights =
+        weights.reorder_if_differ_in(pd.weights_desc(), weights_attr);
 
     tensor expected_dst;
-    if (dst.is_empty() || dst.get_desc() != pd.dst_desc()){
-      // If dst buffer are not given by user or user given dst buffer are not under expected format
-      // We need init a new one. "dst.get_desc() != pd.dst_desc()" conditional is setting for
-      // caffe2 caller, it might given a non-empty but uncorrect dst (maybe the size is uncorrect)
+    if (dst.is_empty() || dst.get_desc() != pd.dst_desc()) {
+      // If dst buffer are not given by user or user given dst buffer are not
+      // under expected format We need init a new one. "dst.get_desc() !=
+      // pd.dst_desc()" conditional is setting for caffe2 caller, it might given
+      // a non-empty but uncorrect dst (maybe the size is uncorrect)
       expected_dst.init(pd.dst_desc());
       if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
         // We need copy the content of given buffer if ip is fused with sum
@@ -256,20 +269,22 @@ private:
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    if (with_bias){
+    if (with_bias) {
       auto expected_bias = bias.reorder_if_differ_in(pd.bias_desc(), bias_attr);
-      super(pd).execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_BIAS, expected_bias},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_BIAS, expected_bias},
+           {DNNL_ARG_DST, expected_dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      super(pd).execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_DST, expected_dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
 
     // reorder back to dst's buffer if needed
@@ -277,9 +292,10 @@ private:
         // when dst is empty, expect return buffer allocate by ideep
         dst.get_desc() == expected_dst.get_desc() ||
         // dst and expected_dst is the same under this case
-        !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
-        // for caffe2 caller, get an uncorrect size dst from caller, can return buffer allocate by ideep
-      dst =  expected_dst;
+        !dst.get_desc().has_same_shape_as(expected_dst.get_desc())) {
+      // for caffe2 caller, get an uncorrect size dst from caller, can return
+      // buffer allocate by ideep
+      dst = expected_dst;
     } else {
       dst.feed_from(expected_dst);
     }
@@ -302,9 +318,11 @@ private:
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
-      do_prepare_<with_bias>(param, src_, weights, bias, dst, attr, aprop_kind, aengine);
+      do_prepare_<with_bias>(
+          param, src_, weights, bias, dst, attr, aprop_kind, aengine);
     } else {
-      do_prepare_<with_bias>(param, src, weights, bias, dst, attr, aprop_kind, aengine);
+      do_prepare_<with_bias>(
+          param, src, weights, bias, dst, attr, aprop_kind, aengine);
     }
   }
 
@@ -334,9 +352,9 @@ private:
       src_attr = {0, src_scale};
     }
 
-    IDEEP_ENFORCE(utils::one_of(weights.get_data_type(),
-                                data_type::f32, data_type::bf16),
-            "Incorrect data type in weights");
+    IDEEP_ENFORCE(
+        utils::one_of(weights.get_data_type(), data_type::f32, data_type::bf16),
+        "Incorrect data type in weights");
 
     // align weights data type with src
     dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
@@ -344,9 +362,9 @@ private:
     src_desc = {src.get_dims(), dst_data_type, format_tag::any};
     weights_desc = {weights.get_dims(), dst_data_type, format_tag::any};
     if (with_bias) {
-      IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
-                                  data_type::f32, data_type::bf16),
-                    "Incorrect data type in bias");
+      IDEEP_ENFORCE(
+          utils::one_of(bias.get_data_type(), data_type::f32, data_type::bf16),
+          "Incorrect data type in bias");
       bias_desc = bias.get_desc().to_format_any();
     }
 
@@ -400,13 +418,15 @@ private:
     auto& bias_attr = param._bias_attr;
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc(), src_attr);
-    auto expected_weights = weights.reorder_if_differ_in(pd.weights_desc(), weights_attr);
+    auto expected_weights =
+        weights.reorder_if_differ_in(pd.weights_desc(), weights_attr);
 
     tensor expected_dst;
-    if (dst.is_empty() || dst.get_desc() != pd.dst_desc()){
-      // If dst buffer are not given by user or user given dst buffer are not under expected format
-      // We need init a new one. "dst.get_desc() != pd.dst_desc()" conditional is setting for
-      // caffe2 caller, it might given a non-empty but uncorrect dst (maybe the size is uncorrect)
+    if (dst.is_empty() || dst.get_desc() != pd.dst_desc()) {
+      // If dst buffer are not given by user or user given dst buffer are not
+      // under expected format We need init a new one. "dst.get_desc() !=
+      // pd.dst_desc()" conditional is setting for caffe2 caller, it might given
+      // a non-empty but uncorrect dst (maybe the size is uncorrect)
       expected_dst.init(pd.dst_desc());
       if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
         // We need copy the content of given buffer if ip is fused with sum
@@ -419,20 +439,22 @@ private:
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    if (with_bias){
+    if (with_bias) {
       auto expected_bias = bias.reorder_if_differ_in(pd.bias_desc(), bias_attr);
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_BIAS, expected_bias},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_BIAS, expected_bias},
+           {DNNL_ARG_DST, expected_dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_DST, expected_dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
 
     // reorder back to dst's buffer if needed
@@ -440,25 +462,25 @@ private:
         // when dst is empty, expect return buffer allocate by ideep
         dst.get_desc() == expected_dst.get_desc() ||
         // dst and expected_dst is the same under this case
-        !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
-        // for caffe2 caller, get an uncorrect size dst from caller, can return buffer allocate by ideep
-      dst =  expected_dst;
+        !dst.get_desc().has_same_shape_as(expected_dst.get_desc())) {
+      // for caffe2 caller, get an uncorrect size dst from caller, can return
+      // buffer allocate by ideep
+      dst = expected_dst;
     } else {
       dst.feed_from(expected_dst);
     }
   }
 };
 
-
 struct inner_product_backward_data : public dnnl::inner_product_backward_data {
-
   using super = dnnl::inner_product_backward_data;
 
-  static void compute(const tensor& diff_dst,
-                      const tensor& weights,
-                      const dims& diff_src_dims,
-                      tensor& diff_src,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& diff_dst,
+      const tensor& weights,
+      const dims& diff_src_dims,
+      tensor& diff_src,
+      const engine& aengine = engine::cpu_engine()) {
     auto weights_ = weights;
     if (diff_dst.get_data_type() == data_type::bf16) {
       weights_.init(weights.get_desc().to_type(data_type::bf16));
@@ -485,14 +507,17 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {diff_src_desc, weights_desc, diff_dst_desc}, op_attr, aengine, forward_hints);
+        {diff_src_desc, weights_desc, diff_dst_desc},
+        op_attr,
+        aengine,
+        forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
     tensor expected_diff_src;
-    if (diff_src.is_empty() || diff_src.get_desc() != pd.diff_src_desc()){
-      // If diff_src buffer are not given by user or user given diff_src buffer are not under expected format
-      // We need init a new one
+    if (diff_src.is_empty() || diff_src.get_desc() != pd.diff_src_desc()) {
+      // If diff_src buffer are not given by user or user given diff_src buffer
+      // are not under expected format We need init a new one
       expected_diff_src.init(pd.diff_src_desc());
     } else {
       // The format of given diff_src buffer is expected
@@ -501,15 +526,16 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(),
-                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                       {DNNL_ARG_WEIGHTS, expected_weights},
-                       {DNNL_ARG_DIFF_SRC, expected_diff_src},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+         {DNNL_ARG_WEIGHTS, expected_weights},
+         {DNNL_ARG_DIFF_SRC, expected_diff_src},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
     // reorder back to diff_src's buffer if needed
     if (diff_src.is_empty() ||
-         diff_src.get_desc() == expected_diff_src.get_desc() ||
-         !diff_src.get_desc().has_same_shape_as(expected_diff_src.get_desc())){
+        diff_src.get_desc() == expected_diff_src.get_desc() ||
+        !diff_src.get_desc().has_same_shape_as(expected_diff_src.get_desc())) {
       diff_src = expected_diff_src;
     } else {
       diff_src.feed_from(expected_diff_src);
@@ -519,44 +545,46 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
 
 struct inner_product_backward_weights
     : public dnnl::inner_product_backward_weights {
-
   using super = dnnl::inner_product_backward_weights;
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      tensor& diff_weights,
-                      tensor& diff_bias,
-                      const data_type diff_weight_type = data_type::undef,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const data_type diff_weight_type = data_type::undef,
+      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*with_diff_bias=*/true>(
         src, diff_dst, diff_weights, diff_bias, diff_weight_type);
   }
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      tensor& diff_weights,
-                      const data_type diff_weight_type = data_type::undef,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      tensor& diff_weights,
+      const data_type diff_weight_type = data_type::undef,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
         src, diff_dst, diff_weights, dummy_diff_bias, diff_weight_type);
   }
 
-private:
-  template<bool with_diff_bias = true>
-  static void compute_impl(const tensor& src,
-                           const tensor& diff_dst,
-                           tensor& diff_weights,
-                           tensor& diff_bias,
-                           const data_type diff_weight_type,
-                           const engine& aengine = engine::cpu_engine()) {
+ private:
+  template <bool with_diff_bias = true>
+  static void compute_impl(
+      const tensor& src,
+      const tensor& diff_dst,
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const data_type diff_weight_type,
+      const engine& aengine = engine::cpu_engine()) {
     auto src_desc = src.get_desc().to_format_any();
     auto diff_dst_desc = diff_dst.get_desc().to_format_any();
     auto diff_weights_dims = src.get_dims();
     diff_weights_dims[0] = diff_dst.get_dim(1);
     data_type diff_dst_type = diff_dst.get_data_type();
-    data_type diff_weight_type_in = data_type::undef== diff_weight_type ?
-                                    diff_dst_type : diff_weight_type;
+    data_type diff_weight_type_in =
+        data_type::undef == diff_weight_type ? diff_dst_type : diff_weight_type;
     auto diff_weights_desc =
         tensor::desc(diff_weights_dims, diff_weight_type_in, tag::any);
 
@@ -576,17 +604,24 @@ private:
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = with_diff_bias
-        ? primitive_desc({src_desc, diff_weights_desc, diff_bias_desc,
-                          diff_dst_desc}, op_attr, aengine, forward_hints)
-        : primitive_desc({src_desc, diff_weights_desc, diff_dst_desc},
-                          op_attr, aengine, forward_hints);
+        ? primitive_desc(
+              {src_desc, diff_weights_desc, diff_bias_desc, diff_dst_desc},
+              op_attr,
+              aengine,
+              forward_hints)
+        : primitive_desc(
+              {src_desc, diff_weights_desc, diff_dst_desc},
+              op_attr,
+              aengine,
+              forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     tensor expected_diff_weights;
-    if (diff_weights.is_empty() || diff_weights.get_desc() != pd.diff_weights_desc()){
-      // If diff_weights buffer are not given by user or user given diff_weights buffer are not under expected format
-      // We need init a new one
+    if (diff_weights.is_empty() ||
+        diff_weights.get_desc() != pd.diff_weights_desc()) {
+      // If diff_weights buffer are not given by user or user given diff_weights
+      // buffer are not under expected format We need init a new one
       expected_diff_weights.init(pd.diff_weights_desc());
     } else {
       // The format of given diff_weights buffer is expected
@@ -595,10 +630,11 @@ private:
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                    {DNNL_ARG_SRC, expected_src},
-                    {DNNL_ARG_DIFF_WEIGHTS ,expected_diff_weights},
-                    {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{
+        {DNNL_ARG_DIFF_DST, expected_diff_dst},
+        {DNNL_ARG_SRC, expected_src},
+        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+        {DNNL_ARG_SCRATCHPAD, scratchpad}};
 
     if (with_diff_bias) {
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
@@ -606,10 +642,11 @@ private:
     }
 
     super(pd).execute(stream::default_stream(), args);
-      // reorder back to diff_weights's buffer if needed
+    // reorder back to diff_weights's buffer if needed
     if (diff_weights.is_empty() ||
-         diff_weights.get_desc() == expected_diff_weights.get_desc() ||
-         !diff_weights.get_desc().has_same_shape_as(expected_diff_weights.get_desc())){
+        diff_weights.get_desc() == expected_diff_weights.get_desc() ||
+        !diff_weights.get_desc().has_same_shape_as(
+            expected_diff_weights.get_desc())) {
       diff_weights = expected_diff_weights;
     } else {
       diff_weights.feed_from(expected_diff_weights);
@@ -617,6 +654,6 @@ private:
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/layernorm.hpp
+++ b/include/ideep/operators/layernorm.hpp
@@ -4,17 +4,17 @@
 namespace ideep {
 
 struct layer_normalization_forward : public dnnl::layer_normalization_forward {
-
   using super = dnnl::layer_normalization_forward;
 
-  static void compute(const tensor& src,
-                      const tensor& scale,
-                      const tensor& shift,
-                      tensor& dst,
-                      tensor& mean,
-                      tensor& variance,
-                      float epsilon,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& scale,
+      const tensor& shift,
+      tensor& dst,
+      tensor& mean,
+      tensor& variance,
+      float epsilon,
+      const engine& aengine = engine::cpu_engine()) {
     auto flags = batch_normalization_flag::use_scale_shift;
     auto src_desc = src.get_desc();
     auto op_attr = dnnl::primitive_attr();
@@ -24,33 +24,35 @@ struct layer_normalization_forward : public dnnl::layer_normalization_forward {
         op_attr,
         aengine);
 
-    tensor scale_shift {pd.weights_desc()};
-    auto* scale_shift_buf = static_cast<char *>(scale_shift.get_data_handle());
+    tensor scale_shift{pd.weights_desc()};
+    auto* scale_shift_buf = static_cast<char*>(scale_shift.get_data_handle());
     std::memcpy(scale_shift_buf, scale.get_data_handle(), scale.get_size());
-    std::memcpy(scale_shift_buf + scale.get_size(),
-                shift.get_data_handle(), shift.get_size());
+    std::memcpy(
+        scale_shift_buf + scale.get_size(),
+        shift.get_data_handle(),
+        shift.get_size());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     mean.reinit_if_possible(pd.mean_desc());
     variance.reinit_if_possible(pd.variance_desc());
     dst.reinit_if_possible(pd.dst_desc());
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(),
-                      {{DNNL_ARG_SRC, expected_src},
-                       {DNNL_ARG_SCALE_SHIFT, scale_shift},
-                       {DNNL_ARG_MEAN, mean},
-                       {DNNL_ARG_VARIANCE, variance},
-                       {DNNL_ARG_DST, dst},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC, expected_src},
+         {DNNL_ARG_SCALE_SHIFT, scale_shift},
+         {DNNL_ARG_MEAN, mean},
+         {DNNL_ARG_VARIANCE, variance},
+         {DNNL_ARG_DST, dst},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
-struct layer_normalization_backward :
-    public dnnl::layer_normalization_backward {
-  static void compute() {
-  }
+struct layer_normalization_backward
+    : public dnnl::layer_normalization_backward {
+  static void compute() {}
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/lbr_gru.hpp
+++ b/include/ideep/operators/lbr_gru.hpp
@@ -4,15 +4,13 @@
 namespace ideep {
 
 struct lbr_gru_forward : public dnnl::lbr_gru_forward {
-  static void compute() {
-  }
+  static void compute() {}
 };
 
 struct lbr_gru_backward : public dnnl::lbr_gru_backward {
-  static void compute() {
-  }
+  static void compute() {}
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/lrn.hpp
+++ b/include/ideep/operators/lrn.hpp
@@ -4,19 +4,18 @@
 namespace ideep {
 
 struct lrn_forward : public dnnl::lrn_forward {
-
   using super = dnnl::lrn_forward;
 
-  static void compute(const tensor& src,
-                      tensor& dst,
-                      dim local_size,
-                      float alpha,
-                      float beta,
-                      float k = 1.0,
-                      algorithm aalgorithm = algorithm::lrn_across_channels,
-                      prop_kind aprop_kind = prop_kind::forward_training,
-                      const engine& aengine = engine::cpu_engine()) {
-
+  static void compute(
+      const tensor& src,
+      tensor& dst,
+      dim local_size,
+      float alpha,
+      float beta,
+      float k = 1.0,
+      algorithm aalgorithm = algorithm::lrn_across_channels,
+      prop_kind aprop_kind = prop_kind::forward_training,
+      const engine& aengine = engine::cpu_engine()) {
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
 
@@ -33,7 +32,7 @@ struct lrn_forward : public dnnl::lrn_forward {
     dst.reinit_if_possible(pd.dst_desc());
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {
+    exec_args args{
         {DNNL_ARG_SRC, expected_src},
         {DNNL_ARG_DST, dst},
         {DNNL_ARG_SCRATCHPAD, scratchpad}};
@@ -49,43 +48,50 @@ struct lrn_forward : public dnnl::lrn_forward {
 };
 
 struct lrn_backward : public dnnl::lrn_backward {
-
   using super = dnnl::lrn_backward;
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      const tensor& dst,
-                      tensor& diff_src,
-                      dim local_size,
-                      float alpha,
-                      float beta,
-                      float k = 1.0,
-                      algorithm aalgorithm = algorithm::lrn_across_channels,
-                      const engine& aengine = engine::cpu_engine()) {
-
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      const tensor& dst,
+      tensor& diff_src,
+      dim local_size,
+      float alpha,
+      float beta,
+      float k = 1.0,
+      algorithm aalgorithm = algorithm::lrn_across_channels,
+      const engine& aengine = engine::cpu_engine()) {
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
     // auto src_desc = src.get_desc();
-    auto forward_hints =
-        lrn_forward::primitive_desc({prop_kind::forward_training, aalgorithm,
-                                     src_desc, local_size, alpha, beta, k},
-                                    aengine);
+    auto forward_hints = lrn_forward::primitive_desc(
+        {prop_kind::forward_training,
+         aalgorithm,
+         src_desc,
+         local_size,
+         alpha,
+         beta,
+         k},
+        aengine);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
         {aalgorithm, src_desc, diff_dst.get_desc(), local_size, alpha, beta, k},
-        op_attr, aengine, forward_hints);
-    
+        op_attr,
+        aengine,
+        forward_hints);
+
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {{DNNL_ARG_SRC, src},
-                    {DNNL_ARG_DIFF_DST, expected_diff_dst},
-                    {DNNL_ARG_DIFF_SRC, diff_src},
-                    {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{
+        {DNNL_ARG_SRC, src},
+        {DNNL_ARG_DIFF_DST, expected_diff_dst},
+        {DNNL_ARG_DIFF_SRC, diff_src},
+        {DNNL_ARG_SCRATCHPAD, scratchpad}};
 
     if (dst.has_workspace()) {
       args.insert({DNNL_ARG_WORKSPACE, dst.get_workspace()});
@@ -94,6 +100,6 @@ struct lrn_backward : public dnnl::lrn_backward {
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/lstm.hpp
+++ b/include/ideep/operators/lstm.hpp
@@ -4,15 +4,13 @@
 namespace ideep {
 
 struct lstm_forward : public dnnl::lstm_forward {
-  static void compute() {
-  }
+  static void compute() {}
 };
 
 struct lstm_backward : public dnnl::lstm_backward {
-  static void compute() {
-  }
+  static void compute() {}
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -67,15 +67,39 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      compute_impl</*with_bias=*/false>(src, weights, bias, dst,
-                                        IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
-                                        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
-                                        dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      compute_impl</*with_bias=*/false>(
+          src,
+          weights,
+          bias,
+          dst,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_ZP,
+          IDEEP_EMPTY_ZP,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     } else {
-      compute_impl</*with_bias=*/true>(src, weights, bias, dst,
-                                       IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
-                                       IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
-                                       dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      compute_impl</*with_bias=*/true>(
+          src,
+          weights,
+          bias,
+          dst,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_ZP,
+          IDEEP_EMPTY_ZP,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -91,10 +115,22 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst,
-                                      IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
-                                      IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
-                                      dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    compute_impl</*with_bias=*/false>(
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        IDEEP_EMPTY_SCALE,
+        IDEEP_EMPTY_SCALE,
+        IDEEP_EMPTY_SCALE,
+        IDEEP_EMPTY_ZP,
+        IDEEP_EMPTY_ZP,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
   // 2-in-1 compute for int8 op with bias. Bias is not used if it is empty.
@@ -115,15 +151,39 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      compute_impl</*with_bias=*/false>(src, weights, bias, dst,
-                                        src_scales, weights_scales, dst_scales,
-                                        src_zero_points, dst_zero_points,
-                                        dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      compute_impl</*with_bias=*/false>(
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     } else {
-      compute_impl</*with_bias=*/true>(src, weights, bias, dst,
-                                       src_scales, weights_scales, dst_scales,
-                                       src_zero_points, dst_zero_points,
-                                       dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      compute_impl</*with_bias=*/true>(
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -144,10 +204,22 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst,
-                                      src_scales, weights_scales, dst_scales,
-                                      src_zero_points, dst_zero_points,
-                                      dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    compute_impl</*with_bias=*/false>(
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_points,
+        dst_zero_points,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
   // Prepare for fp32 op
@@ -164,11 +236,29 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      do_prepare</*with_bias=*/false>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
-          attr, dst_type, aengine);
+      do_prepare</*with_bias=*/false>(
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          aengine);
     } else {
-      do_prepare</*with_bias=*/true>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
-          attr, dst_type, aengine);
+      do_prepare</*with_bias=*/true>(
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          aengine);
     }
   }
 
@@ -185,8 +275,17 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    do_prepare</*with_bias=*/false>(param, src, weights, dummy_bias, dst, dst_coeff, sum_coeff,
-        attr, dst_type, aengine);
+    do_prepare</*with_bias=*/false>(
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        dst_type,
+        aengine);
   }
 
   // Prepare for int8 op with bias. Bias is not used if it is empty.
@@ -212,24 +311,66 @@ struct matmul_forward : public dnnl::matmul,
     if (is_dynamic) {
       if (bias.is_empty()) {
         do_prepare_dynamic_quant</*with_bias=*/false>(
-            param, src, weights, bias, dst, weights_scales,
-            sum_coeff, attr, data_type::f32, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            weights_scales,
+            sum_coeff,
+            attr,
+            data_type::f32,
+            aengine);
       } else {
         do_prepare_dynamic_quant</*with_bias=*/true>(
-            param, src, weights, bias, dst, weights_scales,
-            sum_coeff, attr, data_type::f32, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            weights_scales,
+            sum_coeff,
+            attr,
+            data_type::f32,
+            aengine);
       }
     } else {
       if (bias.is_empty()) {
         do_prepare_static_quant</*with_bias=*/false>(
-            param, src, weights, bias, dst,
-            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            src_scales,
+            weights_scales,
+            dst_scales,
+            src_zero_points,
+            dst_zero_points,
+            dst_coeff,
+            sum_coeff,
+            attr,
+            dst_type,
+            alowp_kind,
+            aengine);
       } else {
         do_prepare_static_quant</*with_bias=*/true>(
-            param, src, weights, bias, dst,
-            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            src_scales,
+            weights_scales,
+            dst_scales,
+            src_zero_points,
+            dst_zero_points,
+            dst_coeff,
+            sum_coeff,
+            attr,
+            dst_type,
+            alowp_kind,
+            aengine);
       }
     }
   }
@@ -256,13 +397,34 @@ struct matmul_forward : public dnnl::matmul,
     static tensor dummy_bias;
     if (is_dynamic) {
       do_prepare_dynamic_quant</*with_bias=*/false>(
-          param, src, weights, dummy_bias, dst, weights_scales,
-          sum_coeff, attr, data_type::f32, aengine);
+          param,
+          src,
+          weights,
+          dummy_bias,
+          dst,
+          weights_scales,
+          sum_coeff,
+          attr,
+          data_type::f32,
+          aengine);
     } else {
       do_prepare_static_quant</*with_bias=*/false>(
-          param, src, weights, dummy_bias, dst,
-          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-          dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          dummy_bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -272,11 +434,12 @@ struct matmul_forward : public dnnl::matmul,
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static inline void compute(const matmul_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst) {
+  static inline void compute(
+      const matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     if (bias.is_empty()) {
       do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, weights, bias, dst);
@@ -292,10 +455,11 @@ struct matmul_forward : public dnnl::matmul,
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static inline void compute(const matmul_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      tensor& dst) {
+  static inline void compute(
+      const matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst) {
     static tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -319,12 +483,26 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_compute_dynamic_quant</*with_bias=*/false, reorder_weight>(
-          param, src, weights, bias, dst,
-          src_scales, src_zero_points, dst_coeff, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          src_zero_points,
+          dst_coeff,
+          aengine);
     } else {
       do_compute_dynamic_quant</*with_bias=*/true, reorder_weight>(
-          param, src, weights, bias, dst,
-          src_scales, src_zero_points, dst_coeff, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          src_zero_points,
+          dst_coeff,
+          aengine);
     }
   }
 
@@ -345,8 +523,15 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_compute_dynamic_quant</*with_bias=*/false, reorder_weight>(
-        param, src, weights, dummy_bias, dst,
-        src_scales, src_zero_points, dst_coeff, aengine);
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        src_scales,
+        src_zero_points,
+        dst_coeff,
+        aengine);
   }
 
   // Deprecated 2-in-1 compute
@@ -369,20 +554,45 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      compute_impl</*with_bias=*/false>(src, weights, bias, dst,
-                                        src_scales, weights_scales, dst_scales,
-                                        src_zero_points, dst_zero_points,
-                                        dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      compute_impl</*with_bias=*/false>(
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     } else {
-      compute_impl</*with_bias=*/true>(src, weights, bias, dst,
-                                       src_scales, weights_scales, dst_scales,
-                                       src_zero_points, dst_zero_points,
-                                       dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      compute_impl</*with_bias=*/true>(
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     }
   }
 
   // Deprecated 2-in-1 compute
-  // Without bias. Zero points are passed explicitly as arguments for quantization
+  // Without bias. Zero points are passed explicitly as arguments for
+  // quantization
   static void compute_v2(
       const tensor& src,
       const tensor& weights,
@@ -399,13 +609,26 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst,
-                                      src_scales, weights_scales, dst_scales,
-                                      src_zero_points, dst_zero_points,
-                                      dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    compute_impl</*with_bias=*/false>(
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_points,
+        dst_zero_points,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
-  // Deprecated 2-in-1 compute. With bias. Set zero points to tensors for quantization.
+  // Deprecated 2-in-1 compute. With bias. Set zero points to tensors for
+  // quantization.
   static void compute(
       const tensor& src,
       const tensor& weights,
@@ -420,13 +643,26 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::undef,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
-    compute_impl</*with_bias=*/true>(src, weights, bias, dst,
-                                     src_scales, weights_scales, dst_scales,
-                                     zero_point_t(), zero_point_t(),
-                                     dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    compute_impl</*with_bias=*/true>(
+        src,
+        weights,
+        bias,
+        dst,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        zero_point_t(),
+        zero_point_t(),
+        dst_coeff,
+        sum_coeff,
+        attr,
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
-  // Deprecated 2-in-1 compute. Without bias. Set zero points to tensors for quantization.
+  // Deprecated 2-in-1 compute. Without bias. Set zero points to tensors for
+  // quantization.
   static void compute(
       const tensor& src,
       const tensor& weights,
@@ -441,52 +677,107 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst,
-                                      src_scales, weights_scales, dst_scales,
-                                      zero_point_t(), zero_point_t(),
-                                      dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    compute_impl</*with_bias=*/false>(
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        zero_point_t(),
+        zero_point_t(),
+        dst_coeff,
+        sum_coeff,
+        attr,
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
   // Deprecated. Prepare for int8 op with bias. Bias is not used if it is empty.
   // Static: int8 * int8 -> int8. Dynamic: fp32 * int8 -> fp32
   template <bool is_dynamic = false>
-  static void prepare(matmul_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst,
-                      const float dst_coeff, // default = 1.0f
-                      const float sum_coeff, // for post-op sum, default = 1.0f
-                      const scale_t& src_scales,
-                      const scale_t& weights_scales,
-                      const scale_t& dst_scales,
-                      const zero_point_t& src_zero_points,
-                      const zero_point_t& dst_zero_points,
-                      const attr_t& attr = attr_t(),
-                      const data_type dst_type = data_type::u8,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const float dst_coeff, // default = 1.0f
+      const float sum_coeff, // for post-op sum, default = 1.0f
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_points,
+      const zero_point_t& dst_zero_points,
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::u8,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     if (is_dynamic) {
       if (bias.is_empty()) {
         do_prepare_dynamic_quant</*with_bias=*/false>(
-            param, src, weights, bias, dst, weights_scales,
-            sum_coeff, attr, data_type::f32, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            weights_scales,
+            sum_coeff,
+            attr,
+            data_type::f32,
+            aengine);
       } else {
         do_prepare_dynamic_quant</*with_bias=*/true>(
-            param, src, weights, bias, dst, weights_scales,
-            sum_coeff, attr, data_type::f32, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            weights_scales,
+            sum_coeff,
+            attr,
+            data_type::f32,
+            aengine);
       }
     } else {
       if (bias.is_empty()) {
         do_prepare_static_quant</*with_bias=*/false>(
-            param, src, weights, bias, dst,
-            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            src_scales,
+            weights_scales,
+            dst_scales,
+            src_zero_points,
+            dst_zero_points,
+            dst_coeff,
+            sum_coeff,
+            attr,
+            dst_type,
+            alowp_kind,
+            aengine);
       } else {
         do_prepare_static_quant</*with_bias=*/true>(
-            param, src, weights, bias, dst,
-            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            src_scales,
+            weights_scales,
+            dst_scales,
+            src_zero_points,
+            dst_zero_points,
+            dst_coeff,
+            sum_coeff,
+            attr,
+            dst_type,
+            alowp_kind,
+            aengine);
       }
     }
   }
@@ -512,12 +803,26 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_compute_dynamic_quant</*with_bias=*/false>(
-          param, src, weights, bias, dst,
-          src_scales, src_zero_points, dst_coeff, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          src_zero_points,
+          dst_coeff,
+          aengine);
     } else {
       do_compute_dynamic_quant</*with_bias=*/true>(
-          param, src, weights, bias, dst,
-          src_scales, src_zero_points, dst_coeff, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          src_zero_points,
+          dst_coeff,
+          aengine);
     }
   }
 
@@ -528,26 +833,28 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     auto ndims = weights_dims.size();
     auto x_dims = weights_dims;
-    x_dims[ndims-2] = 1;
-    x_dims[ndims-1] = weights_dims[ndims-2];
+    x_dims[ndims - 2] = 1;
+    x_dims[ndims - 1] = weights_dims[ndims - 2];
     auto y_dims = {x_dims[0], weights_dims[1]};
     if (ndims == 3)
-        y_dims = {x_dims[0], x_dims[1], weights_dims[2]};
+      y_dims = {x_dims[0], x_dims[1], weights_dims[2]};
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 
-    IDEEP_ENFORCE(x_dims.size() == weights_dims.size(),
-                  "Invalid dims for data and weights");
+    IDEEP_ENFORCE(
+        x_dims.size() == weights_dims.size(),
+        "Invalid dims for data and weights");
     tensor::desc x_desc(x_dims, x_dtype, ndims == 2 ? tag::ab : tag::abc);
     tensor::desc y_desc(y_dims, y_dtype, ndims == 2 ? tag::ab : tag::abc);
-    tensor::desc weights_desc(weights_dims , dtype, tag::any);
+    tensor::desc weights_desc(weights_dims, dtype, tag::any);
     attr_t attr;
-    // If runtime src zero point is not set here, slow ref kernel will be used for quantization
+    // If runtime src zero point is not set here, slow ref kernel will be used
+    // for quantization
     attr.set_zero_points(DNNL_ARG_SRC, /* mask */ 0, {DNNL_RUNTIME_S32_VAL});
     auto pd = primitive_desc({x_desc, weights_desc, y_desc}, attr, aengine);
     return pd.weights_desc();
   }
 
-private:
+ private:
   // For 2-in-1 compute: prepare + compute
   // Supports fp32, static int8 and dynamic int8
   template <bool with_bias>
@@ -572,14 +879,36 @@ private:
         weights.has_scale() ? weights.get_scale() : weights_scales;
     if (!weights_scales_in.empty()) { // for int8
       do_prepare_static_quant<with_bias>(
-          param, src, weights, bias, dst,
-          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-          dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     } else {
-      do_prepare<with_bias>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
-                 attr, dst_type, aengine);
+      do_prepare<with_bias>(
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          aengine);
     }
-    do_compute<with_bias, /*reorder_src=*/ true, /*reorder_weight=*/ true>(
+    do_compute<with_bias, /*reorder_src=*/true, /*reorder_weight=*/true>(
         param, src, weights, bias, dst);
   }
 
@@ -596,7 +925,8 @@ private:
       const attr_t& attr = attr_t(),
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
-    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(
+        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
 
     tensor::desc src_desc, weights_desc, bias_desc;
     attr_t& op_attr = param.op_attr;
@@ -620,17 +950,19 @@ private:
     // introduces *an extra reorder* afterwards. Here we keep the weight format
     // untouched thanks to optimizations for both plain and transposed formats
     // in DNNL.
-    IDEEP_ENFORCE(weights.get_data_type() == data_type::f32 ||
-                  weights.get_data_type() == data_type::bf16,
-                  "Incorrect data type in weights");
-    dst_data_type = src.get_data_type() == data_type::bf16 ?
-                    data_type::bf16 : data_type::f32;
+    IDEEP_ENFORCE(
+        weights.get_data_type() == data_type::f32 ||
+            weights.get_data_type() == data_type::bf16,
+        "Incorrect data type in weights");
+    dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
+                                                           : data_type::f32;
     src_desc = src.get_desc().to_type(dst_data_type);
     weights_desc = weights.get_desc().to_type(dst_data_type);
     if (with_bias) {
-      IDEEP_ENFORCE(bias.get_data_type() == data_type::f32 ||
-                    bias.get_data_type() == data_type::bf16,
-                    "Incorrect data type in bias");
+      IDEEP_ENFORCE(
+          bias.get_data_type() == data_type::f32 ||
+              bias.get_data_type() == data_type::bf16,
+          "Incorrect data type in bias");
       bias_desc = bias.get_desc().to_format_any();
       auto bias_scales = scale_t(1, 1.0 / dst_coeff);
       bias_attr = {utils::tensor_scale_mask(1, false), bias_scales};
@@ -640,8 +972,8 @@ private:
       op_attr = attr_t::fuse_sum(sum_coeff);
     }
     int scale_size = 1;
-    op_attr.set_output_scales(utils::op_scale_mask(scale_size),
-                              std::vector<float>(1, dst_coeff));
+    op_attr.set_output_scales(
+        utils::op_scale_mask(scale_size), std::vector<float>(1, dst_coeff));
 
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -665,7 +997,7 @@ private:
       }
     });
     param.primitive = std::move(super(param.pd));
- }
+  }
 
   // For static int8 op (int8 * int8 -> int8)
   template <bool with_bias>
@@ -686,7 +1018,8 @@ private:
       const data_type dst_type = data_type::u8,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
-    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(
+        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
 
     tensor::desc src_desc, weights_desc, bias_desc;
     attr_t& op_attr = param.op_attr;
@@ -704,16 +1037,17 @@ private:
       dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
     }
 
-    auto& weights_scales_in = weights_scales.empty() ? IDEEP_DEF_SCALE : weights_scales;
+    auto& weights_scales_in =
+        weights_scales.empty() ? IDEEP_DEF_SCALE : weights_scales;
 
-    IDEEP_ENFORCE(alowp_kind == u8s8 || alowp_kind == s8s8,
-                  "Unsupported lowp kind");
+    IDEEP_ENFORCE(
+        alowp_kind == u8s8 || alowp_kind == s8s8, "Unsupported lowp kind");
 
     auto src_scales_in = src_scales.empty() ? IDEEP_DEF_SCALE : src_scales;
     auto src_data_type = (alowp_kind == u8s8) ? data_type::u8 : data_type::s8;
-    std::vector<int64_t> src_strides = (ndims == 3) ?
-        std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
-        std::vector<int64_t>({src_dims[1], 1});
+    std::vector<int64_t> src_strides = (ndims == 3)
+        ? std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1})
+        : std::vector<int64_t>({src_dims[1], 1});
     src_desc = tensor::desc(src_dims, src_data_type, tag::any);
     if (src.get_data_type() == data_type::f32) {
       src_attr = {0, src_scales_in};
@@ -722,8 +1056,8 @@ private:
     int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
     weights_desc = weights.get_desc();
     if (weights.get_data_type() == data_type::f32) {
-      weights_attr = {utils::tensor_scale_mask(scale_size, false),
-                      weights_scales_in};
+      weights_attr = {
+          utils::tensor_scale_mask(scale_size, false), weights_scales_in};
     }
 
     // determine dst data type
@@ -738,54 +1072,69 @@ private:
     // fill primitive attr
     scale_t op_scales(scale_size), bias_scales(scale_size);
     dst_scales_in = (dst_scales.empty() || dst_data_type == data_type::f32)
-                        ? IDEEP_DEF_SCALE
-                        : dst_scales;
-    const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
-                                 src_zero_points.empty() ? IDEEP_DEF_ZP : src_zero_points;
+        ? IDEEP_DEF_SCALE
+        : dst_scales;
+    const auto& src_zero_point = src.has_zero_point()
+        ? src.get_zero_point()
+        : src_zero_points.empty() ? IDEEP_DEF_ZP : src_zero_points;
     const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
-    const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point() :
-        dst_zero_points.empty() ? IDEEP_DEF_ZP : dst_zero_points;
+    const auto& dst_zero_point = dst.has_zero_point()
+        ? dst.get_zero_point()
+        : dst_zero_points.empty() ? IDEEP_DEF_ZP : dst_zero_points;
     const auto dst_zero_point_size = static_cast<dim>(dst_zero_point.size());
-    IDEEP_ENFORCE(src_zero_point_size == 1 && dst_zero_point_size == 1,
-                  "DNNL only support 1-dim zero_point");
-    const auto& wei_zero_point = weights.has_zero_point() ?
-                                 weights.get_zero_point() : IDEEP_DEF_ZP;
+    IDEEP_ENFORCE(
+        src_zero_point_size == 1 && dst_zero_point_size == 1,
+        "DNNL only support 1-dim zero_point");
+    const auto& wei_zero_point =
+        weights.has_zero_point() ? weights.get_zero_point() : IDEEP_DEF_ZP;
     const dim wei_zero_point_size = 1;
 
     if (attr.has_op_kind(kind::sum)) {
-      float sum_scale =
-          sum_coeff * dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+      float sum_scale = sum_coeff * dst_scales_in[0] /
+          (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
       op_attr = attr_t::fuse_sum(sum_scale);
     }
 
-    auto bias_scales_in =
-        bias.has_scale() ? bias.get_scale() : IDEEP_DEF_SCALE;
-    bias_scales_in = bias_scales_in.size() == 1 ?
-        std::vector<float>(scale_size, bias_scales_in[0]) : bias_scales_in;
+    auto bias_scales_in = bias.has_scale() ? bias.get_scale() : IDEEP_DEF_SCALE;
+    bias_scales_in = bias_scales_in.size() == 1
+        ? std::vector<float>(scale_size, bias_scales_in[0])
+        : bias_scales_in;
     for (int i = 0; i < scale_size; i++) {
-      bias_scales[i] = src_scales_in[0] * weights_scales_in[i] / (dst_coeff * bias_scales_in[i]);
-      op_scales[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
+      bias_scales[i] = src_scales_in[0] * weights_scales_in[i] /
+          (dst_coeff * bias_scales_in[i]);
+      op_scales[i] = dst_coeff * dst_scales_in[0] /
+          (src_scales_in[0] * weights_scales_in[i]);
     }
     op_attr.set_output_scales(utils::op_scale_mask(scale_size), op_scales);
-    op_attr.set_zero_points(DNNL_ARG_SRC,
-                            utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
+    op_attr.set_zero_points(
+        DNNL_ARG_SRC,
+        utils::tensor_zp_mask(src_zero_point.size()),
+        src_zero_point);
     if (src.get_data_type() == data_type::f32) {
       // Set zero point for src reorder (fp32 -> int8).
       // First arg should be DNNL_ARG_DST rather than DNNL_ARG_SRC
-      src_attr.set_zero_points(DNNL_ARG_DST,
-                               utils::tensor_zp_mask(src_zero_point.size()),
-                               src_zero_point);
+      src_attr.set_zero_points(
+          DNNL_ARG_DST,
+          utils::tensor_zp_mask(src_zero_point.size()),
+          src_zero_point);
     }
-    op_attr.set_zero_points(DNNL_ARG_WEIGHTS,
-                            utils::tensor_zp_mask(1), zero_point_t(1,wei_zero_point[0]));
+    op_attr.set_zero_points(
+        DNNL_ARG_WEIGHTS,
+        utils::tensor_zp_mask(1),
+        zero_point_t(1, wei_zero_point[0]));
     if (dst_data_type != data_type::f32) {
-      op_attr.set_zero_points(DNNL_ARG_DST,
-                              utils::tensor_zp_mask(dst_zero_point.size()), dst_zero_point);
+      op_attr.set_zero_points(
+          DNNL_ARG_DST,
+          utils::tensor_zp_mask(dst_zero_point.size()),
+          dst_zero_point);
     }
 
     if (with_bias) {
       tag bia_tag = bias.get_dims().size() == 2 ? tag::ab : tag::abc;
-      bias_desc = {bias.get_dims(), data_type::f32, bia_tag}; // Use f32 instead of s32 to improve accuracy
+      bias_desc = {
+          bias.get_dims(),
+          data_type::f32,
+          bia_tag}; // Use f32 instead of s32 to improve accuracy
       if (bias.get_data_type() != data_type::s32) {
         auto ndims = bias.get_dims().size();
         int mask = scale_size > 1 ? 1 << (ndims - 1) : 0;
@@ -815,7 +1164,7 @@ private:
       }
     });
     param.primitive = std::move(super(param.pd));
- }
+  }
 
   // For dynamic int8 op (fp32 * int8 -> fp32)
   template <bool with_bias>
@@ -837,13 +1186,15 @@ private:
      * - Create reorder primitive for src (fp32 -> int8)
      */
 
-    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(
+        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
     if (!param.dq_param_ptr) {
       param.dq_param_ptr = std::make_shared<matmul_forward_dyn_quant_params>();
     }
-    IDEEP_ENFORCE(param.dq_param_ptr, "Failed to allocate memory for parameters");
+    IDEEP_ENFORCE(
+        param.dq_param_ptr, "Failed to allocate memory for parameters");
 
-    tensor::desc &src_desc = param.dq_param_ptr->src_desc;
+    tensor::desc& src_desc = param.dq_param_ptr->src_desc;
     attr_t& op_attr = param.op_attr;
     attr_t src_attr;
 
@@ -851,22 +1202,26 @@ private:
     tensor::dims dst_dims = {src_dims[0], weights.get_dim(1)};
     auto ndims = weights.ndims();
     if (ndims == 3)
-        dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
+      dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
 
     auto& weights_scales_in =
         weights.has_scale() ? weights.get_scale() : weights_scales;
 
     auto src_data_type = data_type::u8;
-    std::vector<int64_t> src_strides = (ndims == 3) ?
-        std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
-        std::vector<int64_t>({src_dims[1], 1});
+    std::vector<int64_t> src_strides = (ndims == 3)
+        ? std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1})
+        : std::vector<int64_t>({src_dims[1], 1});
     src_desc = tensor::desc(src_dims, src_data_type, src_strides);
 
     // Prepare tensor of weight zero point
     static auto wei_zero_point = zero_point_t(1);
     const dim wei_zero_point_size = 1;
-    tensor::desc wei_zero_point_desc = {{wei_zero_point_size}, data_type::s32, {1}};
-    tensor wei_zero_point_m(wei_zero_point_desc, reinterpret_cast<int*>(wei_zero_point.data()), aengine);
+    tensor::desc wei_zero_point_desc = {
+        {wei_zero_point_size}, data_type::s32, {1}};
+    tensor wei_zero_point_m(
+        wei_zero_point_desc,
+        reinterpret_cast<int*>(wei_zero_point.data()),
+        aengine);
 
     // Post-ops
     // For dynamic quantization, bias is applied by post-op add
@@ -880,10 +1235,9 @@ private:
     for (int i = 0; i < pops.len(); ++i) {
       // Only sum and eltwise is supported now
       if (kind::sum == pops.kind(i)) {
-        // The parameter sum_coeff is passed in explicitly now due to legacy code.
-        // TO-DO:
-        // Remove the argument 'sum_coeff'.
-        // User should prepare all post-ops in argument 'attr'.
+        // The parameter sum_coeff is passed in explicitly now due to legacy
+        // code. TO-DO: Remove the argument 'sum_coeff'. User should prepare all
+        // post-ops in argument 'attr'.
         new_pops.append_sum(sum_coeff);
       } else if (kind::eltwise == pops.kind(i)) {
         float scale = 1.0, alpha = 1.0, beta = 0.0;
@@ -895,32 +1249,38 @@ private:
     op_attr.set_post_ops(new_pops);
 
     // fill primitive attr
-    op_attr.set_output_scales(utils::op_scale_mask(1/* scale_size */), {DNNL_RUNTIME_F32_VAL});
-    op_attr.set_zero_points(DNNL_ARG_SRC, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
-    op_attr.set_zero_points(DNNL_ARG_WEIGHTS, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    op_attr.set_output_scales(
+        utils::op_scale_mask(1 /* scale_size */), {DNNL_RUNTIME_F32_VAL});
+    op_attr.set_zero_points(
+        DNNL_ARG_SRC, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    op_attr.set_zero_points(
+        DNNL_ARG_WEIGHTS, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     // Src attr for reorder
     src_attr.set_output_scales(utils::op_scale_mask(1), {DNNL_RUNTIME_F32_VAL});
-    src_attr.set_zero_points(DNNL_ARG_DST, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    src_attr.set_zero_points(
+        DNNL_ARG_DST, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
 
     // Dst desc
-    std::vector<int64_t> dst_strides = (ndims == 3) ?
-        std::vector<int64_t>({dst_dims[2]* dst_dims[1], dst_dims[1], 1}) :
-        std::vector<int64_t>({dst_dims[1], 1});
+    std::vector<int64_t> dst_strides = (ndims == 3)
+        ? std::vector<int64_t>({dst_dims[2] * dst_dims[1], dst_dims[1], 1})
+        : std::vector<int64_t>({dst_dims[1], 1});
     tensor::desc dst_desc = tensor::desc(dst_dims, dst_type, dst_strides);
 
     // Create pd and primitive
-    param.pd = primitive_desc({src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
+    param.pd = primitive_desc(
+        {src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
     param.primitive = super(param.pd);
 
     // Create src reorder primitive with runtime scales/zero point
-    auto src_reorder_pd = dnnl::reorder::primitive_desc(aengine, src.get_desc(), aengine, src_desc, src_attr);
+    auto src_reorder_pd = dnnl::reorder::primitive_desc(
+        aengine, src.get_desc(), aengine, src_desc, src_attr);
     param.dq_param_ptr->src_reorder = dnnl::reorder(src_reorder_pd);
 
     param.dq_param_ptr->weight_scales = std::move(weights_scales_in);
     param.dq_param_ptr->wei_zero_point_m = std::move(wei_zero_point_m);
- }
+  }
 
   // For fp32 and static int8 op (int8 * int8 -> int8)
   // Set reorder flags to false if you are sure the memory layout aligns
@@ -944,74 +1304,77 @@ private:
     auto expected_wei_desc = pd.weights_desc();
     auto expected_dst_desc = pd.dst_desc();
 
-    auto& expected_src = reorder_src ?
-                         src.reorder_if_differ_in(expected_src_desc, src_attr) :
-                         src;
-    auto& expected_weights = reorder_weight ?
-                             weights.reorder_if_differ_in(expected_wei_desc, weights_attr) :
-                             weights;
+    auto& expected_src = reorder_src
+        ? src.reorder_if_differ_in(expected_src_desc, src_attr)
+        : src;
+    auto& expected_weights = reorder_weight
+        ? weights.reorder_if_differ_in(expected_wei_desc, weights_attr)
+        : weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     if (reorder_src) {
       tensor expected_dst;
-      if (dst.is_empty() || dst.get_desc() != expected_dst_desc){
-        // If dst buffer are not given by user or user given dst buffer are not under expected format
-        // We need init a new one
+      if (dst.is_empty() || dst.get_desc() != expected_dst_desc) {
+        // If dst buffer are not given by user or user given dst buffer are not
+        // under expected format We need init a new one
         expected_dst.init(expected_dst_desc);
         if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
-          // We need copy the content of given buffer if matmul is fused with sum
+          // We need copy the content of given buffer if matmul is fused with
+          // sum
           expected_dst.feed_from(dst);
         }
       } else {
         // The format of given dst buffer is expected
         expected_dst = dst;
       }
-      if (with_bias){
-        auto& expected_bias = reorder_weight ?
-                             bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                             bias;
-        primitive.execute(stream::default_stream(),
-                          {{DNNL_ARG_SRC, expected_src},
-                           {DNNL_ARG_WEIGHTS, expected_weights},
-                           {DNNL_ARG_BIAS, expected_bias},
-                           {DNNL_ARG_DST, expected_dst},
-                           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      if (with_bias) {
+        auto& expected_bias = reorder_weight
+            ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
+            : bias;
+        primitive.execute(
+            stream::default_stream(),
+            {{DNNL_ARG_SRC, expected_src},
+             {DNNL_ARG_WEIGHTS, expected_weights},
+             {DNNL_ARG_BIAS, expected_bias},
+             {DNNL_ARG_DST, expected_dst},
+             {DNNL_ARG_SCRATCHPAD, scratchpad}});
       } else {
-        primitive.execute(stream::default_stream(),
-                          {{DNNL_ARG_SRC, expected_src},
-                           {DNNL_ARG_WEIGHTS, expected_weights},
-                           {DNNL_ARG_DST, expected_dst},
-                           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+        primitive.execute(
+            stream::default_stream(),
+            {{DNNL_ARG_SRC, expected_src},
+             {DNNL_ARG_WEIGHTS, expected_weights},
+             {DNNL_ARG_DST, expected_dst},
+             {DNNL_ARG_SCRATCHPAD, scratchpad}});
       }
       // reorder back to dst's buffer if needed
-      if (dst.is_empty() ||
-            dst.get_desc() == expected_dst.get_desc() ||
-            !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
-        dst =  expected_dst;
+      if (dst.is_empty() || dst.get_desc() == expected_dst.get_desc() ||
+          !dst.get_desc().has_same_shape_as(expected_dst.get_desc())) {
+        dst = expected_dst;
       } else {
         dst.feed_from(expected_dst);
       }
     } else {
       tensor& expected_dst = dst;
-      if (with_bias){
-        auto& expected_bias = reorder_weight ?
-                             bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                             bias;
-        primitive.execute(stream::default_stream(),
-                          {{DNNL_ARG_SRC, expected_src},
-                           {DNNL_ARG_WEIGHTS, expected_weights},
-                           {DNNL_ARG_BIAS, expected_bias},
-                           {DNNL_ARG_DST, expected_dst},
-                           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      if (with_bias) {
+        auto& expected_bias = reorder_weight
+            ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
+            : bias;
+        primitive.execute(
+            stream::default_stream(),
+            {{DNNL_ARG_SRC, expected_src},
+             {DNNL_ARG_WEIGHTS, expected_weights},
+             {DNNL_ARG_BIAS, expected_bias},
+             {DNNL_ARG_DST, expected_dst},
+             {DNNL_ARG_SCRATCHPAD, scratchpad}});
       } else {
-        primitive.execute(stream::default_stream(),
-                          {{DNNL_ARG_SRC, expected_src},
-                           {DNNL_ARG_WEIGHTS, expected_weights},
-                           {DNNL_ARG_DST, expected_dst},
-                           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+        primitive.execute(
+            stream::default_stream(),
+            {{DNNL_ARG_SRC, expected_src},
+             {DNNL_ARG_WEIGHTS, expected_weights},
+             {DNNL_ARG_DST, expected_dst},
+             {DNNL_ARG_SCRATCHPAD, scratchpad}});
       }
     }
-
   }
 
   // For dynamic int8 op (fp32 * int8 -> fp32)
@@ -1029,7 +1392,8 @@ private:
       const zero_point_t& src_zero_points,
       const float dst_coeff = 1.0f,
       const engine& aengine = engine::cpu_engine()) {
-    /* Compute for dynamic quantized linear. This function does the following things:
+    /* Compute for dynamic quantized linear. This function does the following
+     * things:
      * - Get matmul primitive from param
      * - Get reorder primitive for src from param.dq_param_ptr
      * - Prepare tensors of output scales and zero points.
@@ -1037,7 +1401,8 @@ private:
      */
 
     // Get primitive, etc. from param
-    IDEEP_ENFORCE(param.dq_param_ptr, "Parameters for dynamic quantization not found");
+    IDEEP_ENFORCE(
+        param.dq_param_ptr, "Parameters for dynamic quantization not found");
     auto& pd = param.pd;
     auto& primitive = param.primitive;
     auto& op_attr = param.op_attr;
@@ -1045,77 +1410,88 @@ private:
     auto& weights_scales_in = param.dq_param_ptr->weight_scales;
     auto& expected_src_desc = param.dq_param_ptr->src_desc;
     auto& wei_zero_point_m = param.dq_param_ptr->wei_zero_point_m;
-    auto &src_reorder = param.dq_param_ptr->src_reorder;
+    auto& src_reorder = param.dq_param_ptr->src_reorder;
     auto expected_dst_desc = dst.get_desc();
 
     // Prepare tensor of output scales
     int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
-    auto src_scales_in =
-        src.has_scale() ? src.get_scale()
-                        : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
+    auto src_scales_in = src.has_scale()
+        ? src.get_scale()
+        : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
     auto& dst_scales_in = IDEEP_DEF_SCALE;
 
     tensor::desc scales_desc = {{scale_size}, data_type::f32, {1}};
     tensor scales_m(scales_desc, aengine);
-    auto s = reinterpret_cast<float *>(scales_m.get_data_handle());
+    auto s = reinterpret_cast<float*>(scales_m.get_data_handle());
     for (memory::dim i = 0; i < scale_size; ++i) {
-      s[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
+      s[i] = dst_coeff * dst_scales_in[0] /
+          (src_scales_in[0] * weights_scales_in[i]);
     }
 
     // Prepare tensor of src scales
     auto src_scale_size = src_scales_in.size();
     tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, {1}};
-    tensor src_scales_m(src_scales_desc, reinterpret_cast<float*>(src_scales_in.data()), aengine);
+    tensor src_scales_m(
+        src_scales_desc,
+        reinterpret_cast<float*>(src_scales_in.data()),
+        aengine);
 
     // Prepare tensor of src zero point
     static const zero_point_t default_zero_points = zero_point_t(1);
-    auto src_zero_point = src.has_zero_point() ? src.get_zero_point() :
-                              src_zero_points.empty() ? default_zero_points : src_zero_points;
+    auto src_zero_point = src.has_zero_point()
+        ? src.get_zero_point()
+        : src_zero_points.empty() ? default_zero_points : src_zero_points;
     const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
-    IDEEP_ENFORCE(src_zero_point_size == 1,
-                  "DNNL only support 1-dim zero_point");
-    tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, {1}};
-    tensor src_zero_point_m(src_zero_point_desc, reinterpret_cast<int32_t*>(src_zero_point.data()), aengine);
+    IDEEP_ENFORCE(
+        src_zero_point_size == 1, "DNNL only support 1-dim zero_point");
+    tensor::desc src_zero_point_desc = {
+        {src_zero_point_size}, data_type::s32, {1}};
+    tensor src_zero_point_m(
+        src_zero_point_desc,
+        reinterpret_cast<int32_t*>(src_zero_point.data()),
+        aengine);
 
     // Reroder src (f32 -> u8)
     tensor expected_src(expected_src_desc);
-    src_reorder.execute(stream::default_stream(),
-                        {{DNNL_ARG_FROM, src},
-                         {DNNL_ARG_TO, expected_src},
-                         {DNNL_ARG_ATTR_OUTPUT_SCALES, src_scales_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, src_zero_point_m}});
+    src_reorder.execute(
+        stream::default_stream(),
+        {{DNNL_ARG_FROM, src},
+         {DNNL_ARG_TO, expected_src},
+         {DNNL_ARG_ATTR_OUTPUT_SCALES, src_scales_m},
+         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, src_zero_point_m}});
 
     // Check weight desc
-    auto& expected_weights = reorder_weight ?
-                             weights.reorder_if_differ_in(pd.weights_desc(), weights_attr) :
-                             weights;
-    tensor &expected_dst = dst;
+    auto& expected_weights = reorder_weight
+        ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
+        : weights;
+    tensor& expected_dst = dst;
 
     tensor scratchpad(pd.scratchpad_desc());
-    if (with_bias){
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, bias},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    if (with_bias) {
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, bias},
+           {DNNL_ARG_DST, expected_dst},
+           {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_DST, expected_dst},
+           {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
-
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/pool.hpp
+++ b/include/ideep/operators/pool.hpp
@@ -6,21 +6,21 @@ namespace ideep {
 // while pooling_forward/backward does not.
 
 struct pooling_forward : public dnnl::pooling_forward {
-
   using super = dnnl::pooling_forward;
 
-  static void compute(const tensor& src,
-                      const dims& output_sizes,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& kernel,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      algorithm aalgorithm,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const dims& output_sizes,
+      tensor& dst,
+      const dims& strides,
+      const dims& kernel,
+      const dims& padding_l,
+      const dims& padding_r,
+      algorithm aalgorithm,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     bool with_workspace = aprop_kind == prop_kind::forward_training &&
-                          aalgorithm == dnnl::algorithm::pooling_max;
+        aalgorithm == dnnl::algorithm::pooling_max;
 
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
@@ -32,8 +32,16 @@ struct pooling_forward : public dnnl::pooling_forward {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aprop_kind, aalgorithm, src_desc, dst_desc, strides, kernel, padding_l,
-         padding_r}, op_attr, aengine);
+        {aprop_kind,
+         aalgorithm,
+         src_desc,
+         dst_desc,
+         strides,
+         kernel,
+         padding_l,
+         padding_r},
+        op_attr,
+        aengine);
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     dst.reinit_if_possible(pd.dst_desc());
@@ -43,7 +51,7 @@ struct pooling_forward : public dnnl::pooling_forward {
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {
+    exec_args args{
         {DNNL_ARG_SRC, expected_src},
         {DNNL_ARG_DST, dst},
         {DNNL_ARG_SCRATCHPAD, scratchpad}};
@@ -57,22 +65,22 @@ struct pooling_forward : public dnnl::pooling_forward {
 };
 
 struct pooling_v2_forward : public dnnl::pooling_v2_forward {
-
   using super = dnnl::pooling_v2_forward;
 
-  static void compute(const tensor& src,
-                      const dims& output_sizes,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& kernel,
-                      const dims& dilation,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      algorithm aalgorithm,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const dims& output_sizes,
+      tensor& dst,
+      const dims& strides,
+      const dims& kernel,
+      const dims& dilation,
+      const dims& padding_l,
+      const dims& padding_r,
+      algorithm aalgorithm,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     bool with_workspace = aprop_kind == prop_kind::forward_training &&
-                          aalgorithm == dnnl::algorithm::pooling_max;
+        aalgorithm == dnnl::algorithm::pooling_max;
 
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
@@ -86,8 +94,17 @@ struct pooling_v2_forward : public dnnl::pooling_v2_forward {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aprop_kind, aalgorithm, src_desc, dst_desc, strides, kernel,
-         dil_compatible, padding_l, padding_r}, op_attr, aengine);
+        {aprop_kind,
+         aalgorithm,
+         src_desc,
+         dst_desc,
+         strides,
+         kernel,
+         dil_compatible,
+         padding_l,
+         padding_r},
+        op_attr,
+        aengine);
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     dst.reinit_if_possible(pd.dst_desc());
@@ -97,7 +114,7 @@ struct pooling_v2_forward : public dnnl::pooling_v2_forward {
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {
+    exec_args args{
         {DNNL_ARG_SRC, expected_src},
         {DNNL_ARG_DST, dst},
         {DNNL_ARG_SCRATCHPAD, scratchpad}};
@@ -112,42 +129,51 @@ struct pooling_v2_forward : public dnnl::pooling_v2_forward {
 };
 
 struct pooling_backward : public dnnl::pooling_backward {
-
   using super = dnnl::pooling_backward;
 
-  static void compute(const tensor& diff_dst,
-                      const tensor& dst,
-                      const tensor& src,
-                      tensor& diff_src,
-                      const dims& strides,
-                      const dims& kernel,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      algorithm aalgorithm,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& diff_dst,
+      const tensor& dst,
+      const tensor& src,
+      tensor& diff_src,
+      const dims& strides,
+      const dims& kernel,
+      const dims& padding_l,
+      const dims& padding_r,
+      algorithm aalgorithm,
+      const engine& aengine = engine::cpu_engine()) {
     auto src_desc = src.get_desc();
     auto dst_desc = dst.get_desc();
 
-    auto forward_hints =
-        pooling_forward::primitive_desc(
-            {prop_kind::forward, aalgorithm, src_desc, dst_desc, strides,
-             kernel, padding_l, padding_r}, aengine);
+    auto forward_hints = pooling_forward::primitive_desc(
+        {prop_kind::forward,
+         aalgorithm,
+         src_desc,
+         dst_desc,
+         strides,
+         kernel,
+         padding_l,
+         padding_r},
+        aengine);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
         {aalgorithm, src_desc, dst_desc, strides, kernel, padding_l, padding_r},
-        op_attr, aengine, forward_hints);
+        op_attr,
+        aengine,
+        forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                    {DNNL_ARG_DIFF_SRC, diff_src},
-                    {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{
+        {DNNL_ARG_DIFF_DST, expected_diff_dst},
+        {DNNL_ARG_DIFF_SRC, diff_src},
+        {DNNL_ARG_SCRATCHPAD, scratchpad}};
 
     if (dst.has_workspace()) {
       auto expected_workspace =
@@ -160,43 +186,60 @@ struct pooling_backward : public dnnl::pooling_backward {
 };
 
 struct pooling_v2_backward : public dnnl::pooling_v2_backward {
-
   using super = dnnl::pooling_v2_backward;
 
-  static void compute(const tensor& diff_dst,
-                      const tensor& dst,
-                      const tensor& src,
-                      tensor& diff_src,
-                      const dims& strides,
-                      const dims& kernel,
-                      const dims& dilation,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      algorithm aalgorithm,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& diff_dst,
+      const tensor& dst,
+      const tensor& src,
+      tensor& diff_src,
+      const dims& strides,
+      const dims& kernel,
+      const dims& dilation,
+      const dims& padding_l,
+      const dims& padding_r,
+      algorithm aalgorithm,
+      const engine& aengine = engine::cpu_engine()) {
     auto src_desc = src.get_desc();
     auto dst_desc = dst.get_desc();
     auto dil_compatible = utils::get_compatible_dilates(dilation);
 
-    auto forward_hints =
-        pooling_v2_forward::primitive_desc(
-            {prop_kind::forward, aalgorithm, src_desc, dst_desc, strides,
-             kernel, dil_compatible, padding_l, padding_r}, aengine);
+    auto forward_hints = pooling_v2_forward::primitive_desc(
+        {prop_kind::forward,
+         aalgorithm,
+         src_desc,
+         dst_desc,
+         strides,
+         kernel,
+         dil_compatible,
+         padding_l,
+         padding_r},
+        aengine);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aalgorithm, src_desc, dst_desc, strides, kernel, dil_compatible,
-         padding_l, padding_r}, op_attr, aengine, forward_hints);
+        {aalgorithm,
+         src_desc,
+         dst_desc,
+         strides,
+         kernel,
+         dil_compatible,
+         padding_l,
+         padding_r},
+        op_attr,
+        aengine,
+        forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                    {DNNL_ARG_DIFF_SRC, diff_src},
-                    {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{
+        {DNNL_ARG_DIFF_DST, expected_diff_dst},
+        {DNNL_ARG_DIFF_SRC, diff_src},
+        {DNNL_ARG_SCRATCHPAD, scratchpad}};
     if (dst.has_workspace()) {
       auto expected_workspace =
           dst.get_workspace().reorder_if_differ_in(pd.workspace_desc());
@@ -207,6 +250,6 @@ struct pooling_v2_backward : public dnnl::pooling_v2_backward {
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/softmax.hpp
+++ b/include/ideep/operators/softmax.hpp
@@ -4,65 +4,66 @@
 namespace ideep {
 
 struct softmax_forward : public dnnl::softmax_forward {
-
   using super = dnnl::softmax_forward;
 
-  static void compute(const tensor& src,
-                      tensor& dst,
-                      int softmax_axis,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      tensor& dst,
+      int softmax_axis,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     auto src_desc = src.get_desc();
     dst.reinit_if_possible(src_desc);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    auto pd = primitive_desc(
-        {aprop_kind, src_desc, softmax_axis}, op_attr, aengine);
+    auto pd =
+        primitive_desc({aprop_kind, src_desc, softmax_axis}, op_attr, aengine);
     tensor scratchpad(pd.scratchpad_desc());
     super(pd).execute(
         stream::default_stream(),
         {{DNNL_ARG_SRC, src},
-        {DNNL_ARG_DST, dst},
-        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+         {DNNL_ARG_DST, dst},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
 struct softmax_backward : public dnnl::softmax_backward {
-
   using super = dnnl::softmax_backward;
 
-  static void compute(const tensor& dst,
-                      const tensor& diff_dst,
-                      tensor& diff_src,
-                      int softmax_axis,
-                      const engine& aengine = engine::cpu_engine()) {
-
+  static void compute(
+      const tensor& dst,
+      const tensor& diff_dst,
+      tensor& diff_src,
+      int softmax_axis,
+      const engine& aengine = engine::cpu_engine()) {
     auto forward_hints = softmax_forward::primitive_desc(
         {prop_kind::forward_inference, dst.get_desc(), softmax_axis}, aengine);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    auto pd =
-        primitive_desc({diff_dst.get_desc(), dst.get_desc(), softmax_axis},
-                       op_attr, aengine, forward_hints);
+    auto pd = primitive_desc(
+        {diff_dst.get_desc(), dst.get_desc(), softmax_axis},
+        op_attr,
+        aengine,
+        forward_hints);
     auto expected_dst = dst.reorder_if_differ_in(pd.dst_desc());
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(),
-                      {{DNNL_ARG_DST, expected_dst},
-                       {DNNL_ARG_DIFF_DST, expected_diff_dst},
-                       {DNNL_ARG_DIFF_SRC, diff_src},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
-    
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_DST, expected_dst},
+         {DNNL_ARG_DIFF_DST, expected_diff_dst},
+         {DNNL_ARG_DIFF_SRC, diff_src},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/spliter.hpp
+++ b/include/ideep/operators/spliter.hpp
@@ -4,11 +4,11 @@
 namespace ideep {
 
 struct spliter {
-
-  static std::vector<tensor> compute(const tensor& input,
-                                     std::vector<int32_t>& axis_info,
-                                     int axis,
-                                     bool add_axis = false) {
+  static std::vector<tensor> compute(
+      const tensor& input,
+      std::vector<int32_t>& axis_info,
+      int axis,
+      bool add_axis = false) {
     std::vector<tensor> outputs;
     tensor::dims output_dims(input.get_dims());
     tensor::dims offset_dims(output_dims.size(), 0);
@@ -36,7 +36,6 @@ struct spliter {
   }
 };
 
-
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/sum.hpp
+++ b/include/ideep/operators/sum.hpp
@@ -4,13 +4,13 @@
 namespace ideep {
 
 struct sum : public dnnl::sum {
-
   using super = dnnl::sum;
 
-  static void compute(const scale_t& scales,
-                      const std::vector<tensor>& srcs,
-                      tensor& dst,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const scale_t& scales,
+      const std::vector<tensor>& srcs,
+      tensor& dst,
+      const engine& aengine = engine::cpu_engine()) {
     auto src_descs = utils::fmap(srcs, [](const tensor& t) {
       // "upcast" vector<tensor::desc> to vector<memory::desc>
       return static_cast<memory::desc>(t.get_desc());
@@ -23,7 +23,7 @@ struct sum : public dnnl::sum {
 
     dst.reinit_if_possible(pd.dst_desc());
     tensor scratchpad(pd.scratchpad_desc());
-    exec_args args {{DNNL_ARG_DST, dst}, {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{{DNNL_ARG_DST, dst}, {DNNL_ARG_SCRATCHPAD, scratchpad}};
     for (int i = 0; i < srcs.size(); ++i) {
       args.insert({DNNL_ARG_MULTIPLE_SRC + i, srcs[i]});
     }
@@ -32,6 +32,6 @@ struct sum : public dnnl::sum {
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/vanilla_rnn.hpp
+++ b/include/ideep/operators/vanilla_rnn.hpp
@@ -4,26 +4,46 @@
 namespace ideep {
 
 struct rnn_forward : public dnnl::vanilla_rnn_forward {
-  static void compute(const tensor& src_layer, const tensor& src_iter,
-      const tensor& weights_layer, const tensor& weights_iter, const tensor& bias,
-      const dims& dst_layer_dims, tensor& dst_layer,
-      const dims& dst_iter_dims, tensor& dst_iter,
-      tensor& workspace, rnn_kind akind, dnnl_rnn_direction_t direction,
-      prop_kind aprop_kind = prop_kind::forward_training) {
-  }
+  static void compute(
+      const tensor& src_layer,
+      const tensor& src_iter,
+      const tensor& weights_layer,
+      const tensor& weights_iter,
+      const tensor& bias,
+      const dims& dst_layer_dims,
+      tensor& dst_layer,
+      const dims& dst_iter_dims,
+      tensor& dst_iter,
+      tensor& workspace,
+      rnn_kind akind,
+      dnnl_rnn_direction_t direction,
+      prop_kind aprop_kind = prop_kind::forward_training) {}
 };
 
 struct rnn_backward : public dnnl::vanilla_rnn_backward {
   template <class alloc = utils::allocator>
-  static void compute(const tensor& src_layer, const tensor& src_iter, const tensor& weights_layer,
-      const tensor& weights_iter, const tensor& bias, const tensor& dst_layer, const tensor& dst_iter,
-      const tensor& diff_dst_layer, const tensor& diff_dst_iter, const tensor& workspace,
-      const bool with_bias, tensor& diff_src_layer, tensor& diff_src_iter, tensor& diff_weights_layer,
-      tensor& diff_weights_iter, tensor& diff_bias, rnn_kind akind, dnnl_rnn_direction_t direction,
-      prop_kind aprop_kind = prop_kind::backward) {
-  }
+  static void compute(
+      const tensor& src_layer,
+      const tensor& src_iter,
+      const tensor& weights_layer,
+      const tensor& weights_iter,
+      const tensor& bias,
+      const tensor& dst_layer,
+      const tensor& dst_iter,
+      const tensor& diff_dst_layer,
+      const tensor& diff_dst_iter,
+      const tensor& workspace,
+      const bool with_bias,
+      tensor& diff_src_layer,
+      tensor& diff_src_iter,
+      tensor& diff_weights_layer,
+      tensor& diff_weights_iter,
+      tensor& diff_bias,
+      rnn_kind akind,
+      dnnl_rnn_direction_t direction,
+      prop_kind aprop_kind = prop_kind::backward) {}
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -21,33 +21,38 @@ class tensor : public memory {
     using dims = typename memory::dims;
     using data_type = typename memory::data_type;
 
-    desc() : memory::desc() {};
+    desc() : memory::desc(){};
 
     // copy ctor
-    desc(const desc &adesc)
-        : memory::desc(adesc.data) { set_g(adesc.g()); };
+    desc(const desc& adesc) : memory::desc(adesc.data) {
+      set_g(adesc.g());
+    };
 
     // supplement group info for memory::desc
-    desc(const memory::desc &adesc, dim groups = 1)
-        : memory::desc(adesc.data) { set_g(groups); };
+    desc(const memory::desc& adesc, dim groups = 1) : memory::desc(adesc.data) {
+      set_g(groups);
+    };
 
-    desc &operator=(const desc &adesc) {
+    desc& operator=(const desc& adesc) {
       memory::desc::operator=(adesc);
       set_g(adesc.g());
       return *this;
     }
 
-    desc(const dnnl_memory_desc_t &adata)
-        : memory::desc(adata) {};
+    desc(const dnnl_memory_desc_t& adata) : memory::desc(adata){};
 
-    desc(const dims &adims, data_type adata_type, format_tag aformat_tag)
-        : memory::desc(adims, adata_type, aformat_tag) { set_g(1); }
+    desc(const dims& adims, data_type adata_type, format_tag aformat_tag)
+        : memory::desc(adims, adata_type, aformat_tag) {
+      set_g(1);
+    }
 
-    desc(const dims &adims, data_type adata_type)
+    desc(const dims& adims, data_type adata_type)
         : desc(adims, adata_type, get_default_format(adims)) {}
 
-    desc(const dims &adims, data_type adata_type, const dims &astrides)
-        : memory::desc(adims, adata_type, astrides) { set_g(1); }
+    desc(const dims& adims, data_type adata_type, const dims& astrides)
+        : memory::desc(adims, adata_type, astrides) {
+      set_g(1);
+    }
 
     void to_bytes(utils::bytestring& bytes) const {
       utils::to_bytes(bytes, get_data_type());
@@ -84,10 +89,12 @@ class tensor : public memory {
     /// Return size of specified dimension
     inline dim_t get_dim(int index) const {
       if (!is_grouped()) {
-        if (index < 0 || index >= data.ndims) return static_cast<dim_t>(0);
+        if (index < 0 || index >= data.ndims)
+          return static_cast<dim_t>(0);
         return data.dims[index];
       } else {
-        if (index < 0 || index >= data.ndims - 1) return static_cast<dim_t>(0);
+        if (index < 0 || index >= data.ndims - 1)
+          return static_cast<dim_t>(0);
         return index == 0 ? data.dims[0] * data.dims[1] : data.dims[index + 1];
       }
     }
@@ -98,7 +105,7 @@ class tensor : public memory {
         return dims(data.dims, data.dims + data.ndims);
       } else {
         auto ret = dims(data.dims + 1, data.dims + data.ndims);
-        ret[0] *= data.dims[0];  // g == data.dims[0]
+        ret[0] *= data.dims[0]; // g == data.dims[0]
         return ret;
       }
     }
@@ -121,15 +128,18 @@ class tensor : public memory {
     }
 
     /** returns true if memory descriptor is zero */
-    bool is_zero() const { return data.ndims == 0; }
+    bool is_zero() const {
+      return data.ndims == 0;
+    }
 
     /** returns the number of elements including padding if \param with_padding
      * is true, and the number of data elements otherwise */
     inline dim_t nelems(bool with_padding = false) const {
-      if (is_zero()) return 0;
+      if (is_zero())
+        return 0;
       auto dims = with_padding ? data.padded_dims : data.dims;
-      return std::accumulate(dims, dims + data.ndims, 1,
-                             std::multiplies<dim_t>());
+      return std::accumulate(
+          dims, dims + data.ndims, 1, std::multiplies<dim_t>());
     }
 
     inline bool is_plain() const {
@@ -137,9 +147,10 @@ class tensor : public memory {
     };
 
     inline bool is_default() const {
-      if (!is_plain()) return false;
+      if (!is_plain())
+        return false;
 
-      const auto &strides = blocking_strides();
+      const auto& strides = blocking_strides();
       for (int i = 0; i < data.ndims - 1; i++) {
         if (strides[i] < strides[i + 1]) {
           return false;
@@ -149,55 +160,55 @@ class tensor : public memory {
     }
 
     inline bool is_nhwc() const {
-      if (!is_plain() || data.ndims != 4) return false;
-      const auto &dims = data.dims;
-      const auto &strides = blocking_strides();
+      if (!is_plain() || data.ndims != 4)
+        return false;
+      const auto& dims = data.dims;
+      const auto& strides = blocking_strides();
       const auto n = 0, c = 1, h = 2, w = 3;
-      return strides[n] == dims[h] * dims[w] * dims[c]
-          && strides[h] == dims[w] * dims[c]
-          && strides[w] == dims[c]
-          && strides[c] == 1;
+      return strides[n] == dims[h] * dims[w] * dims[c] &&
+          strides[h] == dims[w] * dims[c] && strides[w] == dims[c] &&
+          strides[c] == 1;
     };
 
     inline bool is_ndhwc() const {
-      if (!is_plain() || data.ndims != 5) return false;
-      const auto &dims = data.dims;
-      const auto &strides = blocking_strides();
-      const auto n = 0, c = 1, d =2, h = 3, w = 4;
-      return strides[n] == dims[d] * dims[h] * dims[w] * dims[c]
-          && strides[d] == dims[h] * dims[w] * dims[c]
-          && strides[h] == dims[w] * dims[c]
-          && strides[w] == dims[c]
-          && strides[c] == 1;
+      if (!is_plain() || data.ndims != 5)
+        return false;
+      const auto& dims = data.dims;
+      const auto& strides = blocking_strides();
+      const auto n = 0, c = 1, d = 2, h = 3, w = 4;
+      return strides[n] == dims[d] * dims[h] * dims[w] * dims[c] &&
+          strides[d] == dims[h] * dims[w] * dims[c] &&
+          strides[h] == dims[w] * dims[c] && strides[w] == dims[c] &&
+          strides[c] == 1;
     }
 
     inline bool is_nchw() const {
-      if (!is_plain() || data.ndims != 4) return false;
-      const auto &dims = data.dims;
-      const auto &strides = blocking_strides();
+      if (!is_plain() || data.ndims != 4)
+        return false;
+      const auto& dims = data.dims;
+      const auto& strides = blocking_strides();
       const auto n = 0, c = 1, h = 2, w = 3;
-      return strides[n] == dims[c] * dims[h] * dims[w]
-          && strides[c] == dims[h] * dims[w]
-          && strides[h] == dims[w]
-          && strides[w] == 1;
+      return strides[n] == dims[c] * dims[h] * dims[w] &&
+          strides[c] == dims[h] * dims[w] && strides[h] == dims[w] &&
+          strides[w] == 1;
     };
 
     inline bool is_iohw() const {
-      if (!is_plain() || data.ndims != 4) return false;
-      const auto &dims = data.dims;
-      const auto &strides = blocking_strides();
+      if (!is_plain() || data.ndims != 4)
+        return false;
+      const auto& dims = data.dims;
+      const auto& strides = blocking_strides();
       const auto o = 0, i = 1, h = 2, w = 3;
-      return strides[i] == dims[o] * dims[h] * dims[w]
-          && strides[o] == dims[h] * dims[w]
-          && strides[h] == dims[w]
-          && strides[w] == 1;
+      return strides[i] == dims[o] * dims[h] * dims[w] &&
+          strides[o] == dims[h] * dims[w] && strides[h] == dims[w] &&
+          strides[w] == 1;
     };
 
     // workaround for issue intel/mkl-dnn#588
     bool is_4c_blocked() {
       const auto& blk = blocking_desc();
-      return blk.inner_nblks == 1
-          && blk.inner_idxs[0] == 1 && blk.inner_blks[0] == 4;
+      return blk.inner_nblks == 1 && blk.inner_idxs[0] == 1 &&
+          blk.inner_blks[0] == 4;
     }
 
     // legacy API for caffe2
@@ -206,11 +217,13 @@ class tensor : public memory {
       // compute compatible block_dims with v0.x
       dims block_dims(data.ndims, 1);
       for (auto i = 0; i < blk.inner_nblks; i++) {
-        block_dims[blk.inner_idxs[i]] *= blk.inner_blks[i]; 
+        block_dims[blk.inner_idxs[i]] *= blk.inner_blks[i];
       }
       for (auto i = 0; i < data.ndims; i++) {
-        if (data.dims[i] < block_dims[i]) continue;
-        if (data.dims[i] % block_dims[i] == 0) continue;
+        if (data.dims[i] < block_dims[i])
+          continue;
+        if (data.dims[i] % block_dims[i] == 0)
+          continue;
         return false;
       }
       return true;
@@ -259,7 +272,7 @@ class tensor : public memory {
     }
 
     // to be replaced with memory_desc_permute_axes in DNNL v1.3
-    desc permute(const std::vector<int> &permute_axes = {}) const {
+    desc permute(const std::vector<int>& permute_axes = {}) const {
       if (data.ndims <= 1) {
         return clone();
       }
@@ -269,13 +282,15 @@ class tensor : public memory {
         perms.resize(data.ndims);
         std::iota(perms.rbegin(), perms.rend(), 0);
       } else {
-        IDEEP_ENFORCE(perms.size() == data.ndims,
-                      "Axes should be size like source tensor.");
+        IDEEP_ENFORCE(
+            perms.size() == data.ndims,
+            "Axes should be size like source tensor.");
         auto perms_sorted = perms;
         std::sort(perms_sorted.begin(), perms_sorted.end());
         for (auto i = 0; i < perms_sorted.size(); ++i) {
-          IDEEP_ENFORCE(perms_sorted[i] == i,
-                        "Axes should be a permutation of 0 to ndim.");
+          IDEEP_ENFORCE(
+              perms_sorted[i] == i,
+              "Axes should be a permutation of 0 to ndim.");
         }
         if (perms_sorted == perms) {
           return clone();
@@ -332,7 +347,7 @@ class tensor : public memory {
     /** inits descriptor with logical dimensions adims and keep the current
      * blocking structure
      */
-    desc to_dims(const dims &adims) const {
+    desc to_dims(const dims& adims) const {
       IDEEP_ENFORCE(adims.size() == data.ndims, "Rank mismatched.");
 
       dnnl_memory_desc_t md;
@@ -359,7 +374,7 @@ class tensor : public memory {
       md.offset0 = 0;
 
       md.format_kind = dnnl_blocked;
-      auto &mblk = md.format_desc.blocking;
+      auto& mblk = md.format_desc.blocking;
       mblk = blk;
 
       for (auto i = 0; i < data.ndims; i++)
@@ -369,8 +384,10 @@ class tensor : public memory {
       for (int d = 0; d < data.ndims; ++d)
         perm[d] = d;
 
-      utils::simultaneous_sort(mblk.strides, perm, data.ndims,
-                               [](dim_t a, dim_t b) { return b - a; });
+      utils::simultaneous_sort(
+          mblk.strides, perm, data.ndims, [](dim_t a, dim_t b) {
+            return b - a;
+          });
 
       dim_t stride = block_size;
       for (int _d = data.ndims - 1; _d >= 0; --_d) {
@@ -379,86 +396,112 @@ class tensor : public memory {
         stride *= md.padded_dims[d] / blocks[d];
       }
 
-      md.extra = dnnl_memory_extra_desc_t {};
+      md.extra = dnnl_memory_extra_desc_t{};
 
       return desc(md);
     }
 
-    const blocking_desc_t &blocking_desc() const {
-      IDEEP_ENFORCE(is_blocking_desc(),
-                    "Cannot get blocking desc on a non-blocking desc");
+    const blocking_desc_t& blocking_desc() const {
+      IDEEP_ENFORCE(
+          is_blocking_desc(),
+          "Cannot get blocking desc on a non-blocking desc");
       return data.format_desc.blocking;
     }
 
    private:
-
     /// Returns dimension vector
     inline dims get_internal_dims() const {
       return dims(data.dims, data.dims + data.ndims);
     }
 
-    const dims_t &padded_dims() const { return data.padded_dims; }
+    const dims_t& padded_dims() const {
+      return data.padded_dims;
+    }
 
-    const dims_t &padded_offsets() const { return data.padded_offsets; }
+    const dims_t& padded_offsets() const {
+      return data.padded_offsets;
+    }
 
-    dim_t offset0() const { return data.offset0; }
+    dim_t offset0() const {
+      return data.offset0;
+    }
 
-    inline format_kind_t format_kind() const { return data.format_kind; }
+    inline format_kind_t format_kind() const {
+      return data.format_kind;
+    }
 
-    bool is_blocking_desc() const { return format_kind() == dnnl_blocked; }
+    bool is_blocking_desc() const {
+      return format_kind() == dnnl_blocked;
+    }
 
-    bool is_wino_desc() const { return format_kind() == dnnl_format_kind_wino; }
+    bool is_wino_desc() const {
+      return format_kind() == dnnl_format_kind_wino;
+    }
 
     bool is_rnn_packed_desc() const {
       return format_kind() == dnnl_format_kind_rnn_packed;
     }
 
     dims_t& blocking_strides() const {
-      IDEEP_ENFORCE(is_blocking_desc(),
-                    "Cannot get blocking desc on a non-blocking desc");
+      IDEEP_ENFORCE(
+          is_blocking_desc(),
+          "Cannot get blocking desc on a non-blocking desc");
       return const_cast<dnnl_memory_desc_t&>(data).format_desc.blocking.strides;
     }
 
     void set_g(dim groups) {
-      auto reserved_size = sizeof(((dnnl_memory_extra_desc_t *)0)->reserved);
+      auto reserved_size = sizeof(((dnnl_memory_extra_desc_t*)0)->reserved);
       auto offset = reserved_size / sizeof(dim) - 1;
-      reinterpret_cast<dim *>(data.extra.reserved)[offset] = groups;
+      reinterpret_cast<dim*>(data.extra.reserved)[offset] = groups;
     }
 
     dim g() const {
-      auto reserved_size = sizeof(((dnnl_memory_extra_desc_t *)0)->reserved);
+      auto reserved_size = sizeof(((dnnl_memory_extra_desc_t*)0)->reserved);
       auto offset = reserved_size / sizeof(dim) - 1;
-      return reinterpret_cast<const dim *>(data.extra.reserved)[offset];
+      return reinterpret_cast<const dim*>(data.extra.reserved)[offset];
     }
 
-    inline bool is_grouped() const { return g() > 1; }
+    inline bool is_grouped() const {
+      return g() > 1;
+    }
   };
 
   desc get_desc() const {
-    const dnnl_memory_desc_t *cdesc;
-    error::wrap_c_api(dnnl_memory_get_memory_desc(get(), &cdesc),
-                      "could not get memory descriptor from a memory");
+    const dnnl_memory_desc_t* cdesc;
+    error::wrap_c_api(
+        dnnl_memory_get_memory_desc(get(), &cdesc),
+        "could not get memory descriptor from a memory");
     return desc(*cdesc);
   }
 
   // For backward compatibility. Will be deprecated.
-  desc get_descriptor() const { return get_desc(); }
+  desc get_descriptor() const {
+    return get_desc();
+  }
 
-  desc dup_desc() const { return get_desc().clone(); }
+  desc dup_desc() const {
+    return get_desc().clone();
+  }
 
   // For backward compatibility. Will be deprecated.
-  desc dup_descriptor() const { return dup_desc(); }
+  desc dup_descriptor() const {
+    return dup_desc();
+  }
 
   // Constructs an tensor with no buffer and zero memory description
-  tensor() { init({}, nullptr); }
+  tensor() {
+    init({}, nullptr);
+  }
 
   /// Constructs a tensor.
   ///
   /// @param desc tensor descriptor.
   /// @param aengine Engine.
   /// @param ahandle handle.
-  tensor(const desc &adesc, void *ahandle,
-         const engine &aengine = engine::cpu_engine()) {
+  tensor(
+      const desc& adesc,
+      void* ahandle,
+      const engine& aengine = engine::cpu_engine()) {
     init(adesc, ahandle, aengine);
   }
 
@@ -466,38 +509,51 @@ class tensor : public memory {
   ///
   /// @param desc tensor descriptor.
   /// @param aengine Engine.
-  tensor(const desc &adesc,
-         const engine &aengine = engine::cpu_engine()) {
+  tensor(const desc& adesc, const engine& aengine = engine::cpu_engine()) {
     init(adesc, aengine);
   }
 
   // format_tag, buffer
-  tensor(const dims &adims, data_type adata_type, format_tag aformat_tag,
-         void *ahandle, const engine &aengine = engine::cpu_engine()) {
+  tensor(
+      const dims& adims,
+      data_type adata_type,
+      format_tag aformat_tag,
+      void* ahandle,
+      const engine& aengine = engine::cpu_engine()) {
     init(adims, adata_type, aformat_tag, ahandle, aengine);
   }
 
   // format_tag, no buffer
-  tensor(const dims &adims, data_type adata_type, format_tag aformat_tag,
-         const engine &aengine = engine::cpu_engine()) {
+  tensor(
+      const dims& adims,
+      data_type adata_type,
+      format_tag aformat_tag,
+      const engine& aengine = engine::cpu_engine()) {
     init(adims, adata_type, aformat_tag, aengine);
   }
 
   // no format_tag, buffer
-  tensor(const dims &adims, data_type adata_type, void *ahandle,
-         const engine &aengine = engine::cpu_engine()) {
+  tensor(
+      const dims& adims,
+      data_type adata_type,
+      void* ahandle,
+      const engine& aengine = engine::cpu_engine()) {
     init(adims, adata_type, ahandle, aengine);
   }
 
   // no format_tag, no buffer
-  tensor(const dims &adims, data_type adata_type,
-         const engine &aengine = engine::cpu_engine()) {
+  tensor(
+      const dims& adims,
+      data_type adata_type,
+      const engine& aengine = engine::cpu_engine()) {
     init(adims, adata_type, aengine);
   }
 
   /// Function that refill tensor with new description. Specifiy extra buffer.
-  void init(const desc &adesc, void *ahandle,
-              const engine &aengine = engine::cpu_engine()) {
+  void init(
+      const desc& adesc,
+      void* ahandle,
+      const engine& aengine = engine::cpu_engine()) {
     buffer_.reset();
     scale_.reset();
     zero_point_.reset();
@@ -506,7 +562,7 @@ class tensor : public memory {
   }
 
   /// Function that refill tensor with new description or buffer
-  void init(const desc &adesc, const engine &aengine = engine::cpu_engine()) {
+  void init(const desc& adesc, const engine& aengine = engine::cpu_engine()) {
     buffer_.reset(aengine.malloc(adesc.get_size()), aengine.free);
     scale_.reset();
     zero_point_.reset();
@@ -515,40 +571,52 @@ class tensor : public memory {
   }
 
   // format_tag, buffer
-  void init(const dims &adims, data_type adata_type, format_tag aformat_tag,
-              void *ahandle, const engine &aengine = engine::cpu_engine()) {
+  void init(
+      const dims& adims,
+      data_type adata_type,
+      format_tag aformat_tag,
+      void* ahandle,
+      const engine& aengine = engine::cpu_engine()) {
     init({adims, adata_type, aformat_tag}, ahandle, aengine);
   }
 
   // format_tag, no buffer
-  void init(const dims &adims, data_type adata_type, format_tag aformat_tag,
-              const engine &aengine = engine::cpu_engine()) {
+  void init(
+      const dims& adims,
+      data_type adata_type,
+      format_tag aformat_tag,
+      const engine& aengine = engine::cpu_engine()) {
     init({adims, adata_type, aformat_tag}, aengine);
   }
 
   // no format_tag, buffer
-  void init(const dims &adims, data_type adata_type, void *ahandle,
-              const engine &aengine = engine::cpu_engine()) {
+  void init(
+      const dims& adims,
+      data_type adata_type,
+      void* ahandle,
+      const engine& aengine = engine::cpu_engine()) {
     init({adims, adata_type, get_default_format(adims)}, ahandle, aengine);
   }
 
   // no format_tag, no buffer
-  void init(const dims &adims, data_type adata_type,
-              const engine &aengine = engine::cpu_engine()) {
+  void init(
+      const dims& adims,
+      data_type adata_type,
+      const engine& aengine = engine::cpu_engine()) {
     init({adims, adata_type, get_default_format(adims)}, aengine);
   }
 
   // legacy API for caffe2
-  void reinit_like(const tensor &t) {
+  void reinit_like(const tensor& t) {
     init(t.get_desc(), t.get_engine());
   }
 
   // legacy API for caffe2
-  void reinit_like(const tensor &t, void *ahandle) {
+  void reinit_like(const tensor& t, void* ahandle) {
     init(t.get_desc(), ahandle, t.get_engine());
   }
 
-  void reinit_if_possible(const desc &expected_desc) {
+  void reinit_if_possible(const desc& expected_desc) {
     auto curr_desc = get_desc();
     if (expected_desc != curr_desc) {
       if (curr_desc.has_same_shape_as(expected_desc)) {
@@ -560,7 +628,7 @@ class tensor : public memory {
   }
 
   /// Copy constructor
-  tensor(const tensor &t)
+  tensor(const tensor& t)
       : memory(t),
         workspace_(t.workspace_),
         scale_(t.scale_),
@@ -569,7 +637,7 @@ class tensor : public memory {
         eng_(t.eng_) {}
 
   /// Move constructor
-  tensor(tensor &&t)
+  tensor(tensor&& t)
       : memory(std::move(t)),
         workspace_(std::move(t.workspace_)),
         scale_(std::move(t.scale_)),
@@ -578,7 +646,7 @@ class tensor : public memory {
         eng_(std::move(t.eng_)) {}
 
   /// Assignment operator
-  tensor &operator=(const tensor &t) {
+  tensor& operator=(const tensor& t) {
     memory::operator=(t);
     buffer_ = t.buffer_;
     scale_ = t.scale_;
@@ -589,7 +657,7 @@ class tensor : public memory {
   }
 
   /// Move assignment operator
-  tensor &operator=(tensor &&t) {
+  tensor& operator=(tensor&& t) {
     memory::operator=(std::move(t));
     buffer_ = std::move(t.buffer_);
     scale_ = std::move(t.scale_);
@@ -600,28 +668,44 @@ class tensor : public memory {
   }
 
   /// Returns the engine of the tensor
-  const engine &get_engine() const { return eng_; }
+  const engine& get_engine() const {
+    return eng_;
+  }
 
   /// Returns number of dimensions
-  inline int ndims() const { return get_desc().get_ndims(); }
+  inline int ndims() const {
+    return get_desc().get_ndims();
+  }
 
   /// Return size of specified dimension
-  inline dim_t get_dim(int index) const { return get_desc().get_dim(index); }
+  inline dim_t get_dim(int index) const {
+    return get_desc().get_dim(index);
+  }
 
   /// Returns dimension vector
-  inline dims get_dims() const { return get_desc().get_dims(); }
+  inline dims get_dims() const {
+    return get_desc().get_dims();
+  }
 
-  inline dims get_strides() const { return get_desc().get_strides(); }
+  inline dims get_strides() const {
+    return get_desc().get_strides();
+  }
 
   /// Return element number of the param.
   /// The number is the meaning values for a tensor, instead of whole buffer.
   /// It is the number without counting in paddings.
-  inline dim_t get_nelems() const { return get_desc().nelems(); }
+  inline dim_t get_nelems() const {
+    return get_desc().nelems();
+  }
 
   /// Returns descriptor data type
-  inline data_type get_data_type() const { return get_desc().get_data_type(); }
+  inline data_type get_data_type() const {
+    return get_desc().get_data_type();
+  }
 
-  inline size_t get_size() const { return get_desc().get_size(); }
+  inline size_t get_size() const {
+    return get_desc().get_size();
+  }
 
   /// Return whether the tensor is empty
   inline bool is_empty() const {
@@ -633,7 +717,7 @@ class tensor : public memory {
     return get_desc().is_plain();
   }
 
-  inline static format_tag get_default_format(const dims &adims) {
+  inline static format_tag get_default_format(const dims& adims) {
     switch (adims.size()) {
       case 1:
         return format_tag::a;
@@ -666,10 +750,14 @@ class tensor : public memory {
     return nchw_dims;
   }
 
-  tensor reorder_if_differ_in(const desc &expected_desc, const attr_t &aattr = attr_t()) const {
+  tensor reorder_if_differ_in(
+      const desc& expected_desc,
+      const attr_t& aattr = attr_t()) const {
     auto output_scales = std::get<0>(aattr.get_output_scales());
-    auto is_empty_or_ones = output_scales.empty()
-        || std::all_of(output_scales.begin(), output_scales.end(), [](float i){return 1.0==i;});
+    auto is_empty_or_ones = output_scales.empty() ||
+        std::all_of(output_scales.begin(), output_scales.end(), [](float i) {
+                              return 1.0 == i;
+                            });
     if (expected_desc == get_desc() && is_empty_or_ones) {
       return *this;
     } else {
@@ -687,21 +775,22 @@ class tensor : public memory {
 
   // no data copy
   tensor make_grouped_weights(int groups, bool is_deconv = false) const {
-    if (groups <= 1) return *this;
+    if (groups <= 1)
+      return *this;
 
     auto old_desc = get_desc();
     auto old_groups = old_desc.g();
     if (old_groups > 1) {
       // weights have already been pre-converted if old_groups > 1
-      IDEEP_ENFORCE(old_groups == groups,
-                    "groups does not match the pre-converted weights");
+      IDEEP_ENFORCE(
+          old_groups == groups,
+          "groups does not match the pre-converted weights");
       return *this;
     }
 
-    auto grouped_desc =
-        is_deconv
-            ? old_desc.transpose(0, 1).to_grouped(groups).transpose(1, 2)
-            : old_desc.to_grouped(groups);
+    auto grouped_desc = is_deconv
+        ? old_desc.transpose(0, 1).to_grouped(groups).transpose(1, 2)
+        : old_desc.to_grouped(groups);
 
     // handle channels last with groups
     if (is_deconv) {
@@ -724,13 +813,15 @@ class tensor : public memory {
         auto d = ddims[2];
         auto h = ddims[3];
         auto w = ddims[4];
-        desc new_desc{{g, o, i, d, h, w}, ddata_type, {
-            /*g*/i * d * h * w * o,
-            /*o*/1,
-            /*i*/d * h * w *o,
-            /*d*/h * w * o,
-            /*h*/w * o,
-            /*w*/o}};
+        desc new_desc{
+            {g, o, i, d, h, w},
+            ddata_type,
+            {/*g*/ i * d * h * w * o,
+             /*o*/ 1,
+             /*i*/ d * h * w * o,
+             /*d*/ h * w * o,
+             /*h*/ w * o,
+             /*w*/ o}};
         grouped_desc = new_desc;
       }
     } else {
@@ -752,16 +843,16 @@ class tensor : public memory {
   /// but reuse the param shell. Notice that after resize, its format
   /// is undefined
   /// legacy API for caffe2
-  void resize(const dims &adims, data_type adata_type) {
+  void resize(const dims& adims, data_type adata_type) {
     init(adims, adata_type, get_engine());
   }
 
   /// Return an new tensor with new shape
-  tensor &reshape(const dims &adims) {
+  tensor& reshape(const dims& adims) {
     IDEEP_ENFORCE(has_same_volume(adims), "reshape to incompatible shape");
 
-    auto need_convert_to_default_format = [](const desc &src_desc,
-                                             const dims &shape) {
+    auto need_convert_to_default_format = [](const desc& src_desc,
+                                             const dims& shape) {
       // if src_desc is default format, do not need to conver format.
       if (src_desc.is_default()) {
         return false;
@@ -784,9 +875,11 @@ class tensor : public memory {
         if (squeezed_ndims == 1) {
           if (src_desc.is_plain())
             return false;
-          // block format, only one dim is blocked, and the size of blocked dim > 1.
+          // block format, only one dim is blocked, and the size of blocked dim
+          // > 1.
           auto block_desc = src_desc.blocking_desc();
-          if (block_desc.inner_nblks == 1 && shape[block_desc.inner_idxs[0]] > 1) {
+          if (block_desc.inner_nblks == 1 &&
+              shape[block_desc.inner_idxs[0]] > 1) {
             return false;
           }
         }
@@ -817,7 +910,7 @@ class tensor : public memory {
     set_desc(get_desc().to_type(adata_type));
   }
 
-  inline void reorder_from(const tensor &src) {
+  inline void reorder_from(const tensor& src) {
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto pd = dnnl::reorder::primitive_desc(src, *this, op_attr);
@@ -830,7 +923,7 @@ class tensor : public memory {
          {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 
-  inline void reorder_to(tensor &dst, const attr_t &aattr = attr_t()) const {
+  inline void reorder_to(tensor& dst, const attr_t& aattr = attr_t()) const {
     attr_t op_attr = aattr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto pd = dnnl::reorder::primitive_desc(*this, dst, op_attr);
@@ -844,11 +937,11 @@ class tensor : public memory {
   }
 
   /// Convert the tensor to public format, and f32 data type by default
-  tensor to_public(void *buffer = nullptr,
-                   data_type dst_type = data_type::f32) const {
+  tensor to_public(void* buffer = nullptr, data_type dst_type = data_type::f32)
+      const {
     auto dst_desc = get_desc();
 
-    // If we get a non-plain blocking format, say `Acdb16A`, we may not be able 
+    // If we get a non-plain blocking format, say `Acdb16A`, we may not be able
     // to recover it to its "unblocked" format `acdb`. Instead, we will convert
     // it to its default format `abcd` based on its dimensions.
     if (!is_public_format()) {
@@ -861,8 +954,8 @@ class tensor : public memory {
 
     auto dst = buffer ? tensor(dst_desc, buffer) : tensor(dst_desc);
 
-    if (utils::one_of(get_data_type(),
-                      data_type::s8, data_type::u8, data_type::s32) &&
+    if (utils::one_of(
+            get_data_type(), data_type::s8, data_type::u8, data_type::s32) &&
         dst_desc.get_data_type() == data_type::f32 && has_scale()) {
       auto& src_scale = get_scale();
       auto dequantize_scale =
@@ -882,8 +975,8 @@ class tensor : public memory {
 
   /// Fill the tensor with a src tensor
   /// TODO(xpz): may replace is_deconv_weights with a enum for other purposes
-  void feed_from(const tensor &src, bool is_deconv_weights = false) {
-  	scale_t dst_scale, src_scale;
+  void feed_from(const tensor& src, bool is_deconv_weights = false) {
+    scale_t dst_scale, src_scale;
     if (has_scale() && src.has_scale()) {
       dst_scale = get_scale();
       src_scale = src.get_scale();
@@ -897,15 +990,15 @@ class tensor : public memory {
       dst_scale = IDEEP_DEF_SCALE;
       src_scale = IDEEP_DEF_SCALE;
     }
-    IDEEP_ENFORCE(dst_scale.size() == src_scale.size(), "Invalid tensor scales");
+    IDEEP_ENFORCE(
+        dst_scale.size() == src_scale.size(), "Invalid tensor scales");
     scale_t scales(dst_scale.size());
     for (int i = 0; i < dst_scale.size(); i++) {
       scales[i] = dst_scale[i] / src_scale[i];
     }
 
     auto groups = 1;
-    if ((groups = get_desc().g()) > 1 ||
-        (groups = src.get_desc().g()) > 1) {
+    if ((groups = get_desc().g()) > 1 || (groups = src.get_desc().g()) > 1) {
       auto mask_dst = this->make_grouped_weights(groups, is_deconv_weights);
       auto mask_src = src.make_grouped_weights(groups, is_deconv_weights);
       int mask = utils::tensor_scale_mask(src_scale.size(), true);
@@ -917,8 +1010,8 @@ class tensor : public memory {
   }
 
   // For backward compatibility. Will be deprecated.
-  void feed_from(const dims &adims, data_type adata_type, const void *array) {
-    feed_from({adims, adata_type, const_cast<void *>(array)});
+  void feed_from(const dims& adims, data_type adata_type, const void* array) {
+    feed_from({adims, adata_type, const_cast<void*>(array)});
   }
 
   tensor dequantize() const {
@@ -927,12 +1020,15 @@ class tensor : public memory {
     // TODO(xpz): support per-channel dequantize
     IDEEP_ENFORCE(get_scale().size() == 1, "Incorrect scale size");
     dst.feed_from(*this);
-    return dst;  
+    return dst;
   }
 
   // reorder src to part of this tensor
-  void insert_submemory(const tensor &src, const dims &adims,
-                        const dims &offsets, const attr_t &attr = attr_t()) {
+  void insert_submemory(
+      const tensor& src,
+      const dims& adims,
+      const dims& offsets,
+      const attr_t& attr = attr_t()) {
     auto view = get_desc().submemory_desc(adims, offsets);
 
     attr_t op_attr = attr;
@@ -949,8 +1045,11 @@ class tensor : public memory {
   }
 
   // reorder part of this tensor to dst
-  void extract_submemory(tensor &dst, const dims &adims, const dims &offsets,
-                         const attr_t &attr = attr_t()) const {
+  void extract_submemory(
+      tensor& dst,
+      const dims& adims,
+      const dims& offsets,
+      const attr_t& attr = attr_t()) const {
     auto view = get_desc().submemory_desc(adims, offsets);
 
     attr_t op_attr = attr;
@@ -967,41 +1066,59 @@ class tensor : public memory {
   }
 
   // simple api for extract_submemory
-  tensor extract_submemory(const dims &adims, const dims &offsets,
-                           const attr_t &attr = attr_t()) const {
+  tensor extract_submemory(
+      const dims& adims,
+      const dims& offsets,
+      const attr_t& attr = attr_t()) const {
     tensor dst{adims, get_data_type(), get_engine()};
     extract_submemory(dst, adims, offsets, attr);
     return dst;
   }
 
-  void init_workspace(const desc &desc) {
+  void init_workspace(const desc& desc) {
     auto workspace = new tensor(desc, get_engine());
     workspace_.reset(workspace);
   }
 
   /// Return extra packed tensor
-  tensor &get_workspace() const { return *workspace_; }
+  tensor& get_workspace() const {
+    return *workspace_;
+  }
 
   /// Decide wether there is an extra tensor packed in
-  bool has_workspace() const { return workspace_ != nullptr; }
+  bool has_workspace() const {
+    return workspace_ != nullptr;
+  }
 
   /// Return the scale of this param.
-  const scale_t &get_scale() const { return *scale_.get(); }
+  const scale_t& get_scale() const {
+    return *scale_.get();
+  }
 
   /// Set new scale into param
-  void set_scale(const scale_t &ascale) { scale_.reset(new scale_t(ascale)); }
+  void set_scale(const scale_t& ascale) {
+    scale_.reset(new scale_t(ascale));
+  }
 
   /// Return whether the param has a scale
-  bool has_scale() const { return scale_ != nullptr && !scale_->empty(); }
+  bool has_scale() const {
+    return scale_ != nullptr && !scale_->empty();
+  }
 
-  /// Return whether the param has a zero_point 
-  bool has_zero_point() const { return zero_point_ != nullptr && !zero_point_->empty(); }
-  
+  /// Return whether the param has a zero_point
+  bool has_zero_point() const {
+    return zero_point_ != nullptr && !zero_point_->empty();
+  }
+
   /// Return the zero_point of this param.
-  const zero_point_t &get_zero_point() const { return *zero_point_.get(); }
+  const zero_point_t& get_zero_point() const {
+    return *zero_point_.get();
+  }
 
   /// Set new scale into param
-  void set_zero_point(const zero_point_t &zp) { zero_point_.reset(new zero_point_t(zp)); }
+  void set_zero_point(const zero_point_t& zp) {
+    zero_point_.reset(new zero_point_t(zp));
+  }
 
   /// Need reorder if current param used by non DNNL routines.
   // legacy API for caffe2
@@ -1009,11 +1126,11 @@ class tensor : public memory {
     return (!is_public_format() || get_data_type() != data_type::f32);
   }
 
-  tensor& permute_(const std::vector<int> &permute_axes = {}) {
+  tensor& permute_(const std::vector<int>& permute_axes = {}) {
     return set_desc(get_desc().permute(permute_axes));
   }
 
-  tensor permute(const std::vector<int> &permute_axes = {}) const {
+  tensor permute(const std::vector<int>& permute_axes = {}) const {
     auto src_mask = *this;
     src_mask.permute_(permute_axes);
     auto dst = tensor(src_mask.get_desc().to_default_format());
@@ -1034,12 +1151,12 @@ class tensor : public memory {
   }
 
   // For backward compatibility. Will be deprecated
-  void transpose_from(const tensor &src, const std::vector<int> &perms = {}) {
+  void transpose_from(const tensor& src, const std::vector<int>& perms = {}) {
     *this = std::move(src.permute(perms));
   }
 
  private:
-  void reset_internal(const desc &adesc, const engine &aengine, void *ahandle) {
+  void reset_internal(const desc& adesc, const engine& aengine, void* ahandle) {
     dnnl_memory_t result;
     error::wrap_c_api(
         dnnl_memory_create(&result, &adesc.data, aengine.get(), ahandle),
@@ -1055,19 +1172,19 @@ class tensor : public memory {
     }
   }
 
-  bool has_same_volume(const dims &new_dims) const {
+  bool has_same_volume(const dims& new_dims) const {
     auto old_dims = get_dims();
-    auto volume_old = std::accumulate(old_dims.begin(), old_dims.end(), 1,
-                                      std::multiplies<dim_t>());
-    auto volume_new = std::accumulate(new_dims.begin(), new_dims.end(), 1,
-                                      std::multiplies<dim_t>());
+    auto volume_old = std::accumulate(
+        old_dims.begin(), old_dims.end(), 1, std::multiplies<dim_t>());
+    auto volume_new = std::accumulate(
+        new_dims.begin(), new_dims.end(), 1, std::multiplies<dim_t>());
     return volume_old == volume_new;
   }
 
   /// Set a descriptor into tensor to replace the older one, keep buffer
   /// It is caller's responsibility to make sure the original buffer is large
   /// enough for specified descriptor
-  tensor& set_desc(const desc &new_desc) {
+  tensor& set_desc(const desc& new_desc) {
     // Keep the original management
     auto buf = std::move(buffer_);
     auto ws = std::move(workspace_);
@@ -1088,5 +1205,5 @@ class tensor : public memory {
   engine eng_;
 };
 
-}  // namespace ideep
+} // namespace ideep
 #endif

--- a/include/ideep/utils.hpp
+++ b/include/ideep/utils.hpp
@@ -1,20 +1,20 @@
 #ifndef IDEEP_UTILS_CPP
 #define IDEEP_UTILS_CPP
 
-#include <string>
-#include <cstring>
-#include <memory>
 #include <algorithm>
-#include <climits>
-#include <random>
-#include <numeric>
 #include <atomic>
 #include <chrono>
-#include <vector>
+#include <climits>
+#include <cstring>
 #include <iterator>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
 #ifdef IDEEP_USE_MKL
-#include <mkl_vsl.h>
 #include <mkl_vml_functions.h>
+#include <mkl_vsl.h>
 #endif
 #include <dnnl.h>
 #include <dnnl.hpp>
@@ -23,8 +23,8 @@
 #else
 #define omp_get_max_threads() 1
 #define omp_get_num_threads() 1
-#define omp_get_thread_num()  0
-#define omp_in_parallel()     0
+#define omp_get_thread_num() 0
+#define omp_in_parallel() 0
 #endif
 
 namespace ideep {
@@ -39,27 +39,30 @@ static void bernoulli_generate(const long n, const double p, int* r) {
 
   int nthr = omp_get_max_threads();
 #ifdef _OPENMP
-  # pragma omp parallel num_threads(nthr)
+#pragma omp parallel num_threads(nthr)
 #endif
   {
     const int ithr = omp_get_thread_num();
     const long avg_amount = (n + nthr - 1) / nthr;
-    const long my_offset = ithr* avg_amount;
+    const long my_offset = ithr * avg_amount;
     const long my_amount = std::min(my_offset + avg_amount, n) - my_offset;
 
     if (my_amount > 0) {
       VSLStreamStatePtr stream;
       vslNewStream(&stream, VSL_BRNG_MCG31, seed);
       vslSkipAheadStream(stream, my_offset);
-      viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, my_amount, r + my_offset, p);
+      viRngBernoulli(
+          VSL_RNG_METHOD_BERNOULLI_ICDF, stream, my_amount, r + my_offset, p);
       vslDeleteStream(&stream);
     }
   }
 #endif
 }
 
-template <typename F, typename T,
-          typename U = decltype(std::declval<F>()(std::declval<T>()))>
+template <
+    typename F,
+    typename T,
+    typename U = decltype(std::declval<F>()(std::declval<T>()))>
 std::vector<U> fmap(const std::vector<T>& vec, const F& f) {
   std::vector<U> result;
   std::transform(vec.begin(), vec.end(), std::back_inserter(result), f);
@@ -68,12 +71,12 @@ std::vector<U> fmap(const std::vector<T>& vec, const F& f) {
 
 template <typename T, typename P>
 constexpr bool one_of(T val, P item) {
-    return val == item;
+  return val == item;
 }
 
 template <typename T, typename P, typename... Args>
 constexpr bool one_of(T val, P item, Args... item_others) {
-    return val == item || one_of(val, item_others...);
+  return val == item || one_of(val, item_others...);
 }
 
 template <typename T>
@@ -81,7 +84,9 @@ inline bool any_le(const std::vector<T>& v, T i) {
   return std::any_of(v.begin(), v.end(), [i](T k) { return k <= i; });
 }
 
-inline memory::dims get_compatible_dilates(const memory::dims& dilates, int input_size = 4) {
+inline memory::dims get_compatible_dilates(
+    const memory::dims& dilates,
+    int input_size = 4) {
   if (!dilates.empty() && !any_le(dilates, static_cast<dim>(0)))
     return fmap(dilates, [](dim x) { return x - 1; });
   if (4 == input_size) {
@@ -91,7 +96,7 @@ inline memory::dims get_compatible_dilates(const memory::dims& dilates, int inpu
   }
 }
 
-inline memory::dims group_dims(const dims &adims, dim groups) {
+inline memory::dims group_dims(const dims& adims, dim groups) {
   auto new_dims = adims;
   new_dims.insert(new_dims.begin(), groups);
   new_dims[1] /= groups;
@@ -121,7 +126,9 @@ inline dnnl::algorithm rnn_kind_to_activation(rnn_kind rnn) {
 }
 
 inline std::pair<std::vector<float>, std::vector<float>> compute_scales(
-    float src_scale, float dst_scale, std::vector<float> weight_scales) {
+    float src_scale,
+    float dst_scale,
+    std::vector<float> weight_scales) {
   auto scale_size = weight_scales.size();
   std::vector<float> bias_scales(scale_size), op_scales(scale_size);
 
@@ -132,11 +139,11 @@ inline std::pair<std::vector<float>, std::vector<float>> compute_scales(
   return std::make_pair(std::move(bias_scales), std::move(op_scales));
 }
 
-
 using bytestring = std::string;
 
 /* Definitions for builtins unavailable on MSVC */
-// see https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/builtins/int_lib.h
+// see
+// https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/builtins/int_lib.h
 #if defined(_MSC_VER) && !defined(__clang__)
 #include <intrin.h>
 uint32_t __inline clz(uint32_t x) {
@@ -153,7 +160,8 @@ uint32_t __inline clz(uint32_t x) {
 
 inline void to_bytes(bytestring& bytes, const int arg) {
   auto as_cstring = reinterpret_cast<const char*>(&arg);
-  if (arg == 0) return;
+  if (arg == 0)
+    return;
   auto len = sizeof(arg) - (clz(arg) / 8);
   bytes.append(as_cstring, len);
 }
@@ -203,27 +211,29 @@ inline void to_bytes(bytestring& bytes, std::vector<T>&& arg) {
   to_bytes(bytes, arg);
 }
 
-template <typename T,
-          typename = typename std::enable_if<std::is_enum<T>::value>::type>
+template <
+    typename T,
+    typename = typename std::enable_if<std::is_enum<T>::value>::type>
 inline void to_bytes(bytestring& bytes, T arg) {
   to_bytes(bytes, static_cast<int>(arg));
 }
 
-template <typename T,
-          typename = typename std::enable_if<std::is_class<T>::value>::type,
-          typename = void>
+template <
+    typename T,
+    typename = typename std::enable_if<std::is_class<T>::value>::type,
+    typename = void>
 inline void to_bytes(bytestring& bytes, const T arg) {
   arg.to_bytes(bytes);
 }
 
-template <typename T, typename ...Ts>
+template <typename T, typename... Ts>
 inline void to_bytes(bytestring& bytes, T&& arg, Ts&&... args) {
   to_bytes(bytes, std::forward<T>(arg));
   bytes.append(1, '*');
   to_bytes(bytes, std::forward<Ts>(args)...);
 }
 
-template <typename ...Ts>
+template <typename... Ts>
 inline key_t create_key(Ts&&... args) {
   key_t k;
   to_bytes(k, std::forward<Ts>(args)...);
@@ -237,20 +247,23 @@ inline key_t create_key(Ts&&... args) {
  *       sorts the array of @vals only.
  */
 template <typename T, typename U, typename F>
-inline void simultaneous_sort(T *vals, U *keys, size_t size, F comparator) {
-  if (size == 0) return;
+inline void simultaneous_sort(T* vals, U* keys, size_t size, F comparator) {
+  if (size == 0)
+    return;
 
   for (auto i = 0; i < size - 1; ++i) {
     bool swapped = false;
     for (auto j = 0; j < size - i - 1; j++) {
       if (comparator(vals[j], vals[j + 1]) > 0) {
         std::swap(vals[j], vals[j + 1]);
-        if (keys) std::swap(keys[j], keys[j + 1]);
+        if (keys)
+          std::swap(keys[j], keys[j + 1]);
         swapped = true;
       }
     }
 
-    if (swapped == false) break;
+    if (swapped == false)
+      break;
   }
 }
 
@@ -271,29 +284,30 @@ inline int tensor_zp_mask(dim zp_size) {
   return zp_size > 1 ? 1 : 0;
 }
 
-inline uintptr_t mod_ptr(void *ptr, size_t bytes) {
+inline uintptr_t mod_ptr(void* ptr, size_t bytes) {
   return reinterpret_cast<uintptr_t>(ptr) & (bytes - 1);
 }
 
-inline bool is_aligned_ptr(void *ptr, size_t bytes) {
+inline bool is_aligned_ptr(void* ptr, size_t bytes) {
   return mod_ptr(ptr, bytes) == 0;
 }
 
 template <typename T>
-inline void array_copy(T *dst, const T *src, size_t size) {
+inline void array_copy(T* dst, const T* src, size_t size) {
   for (auto i = 0; i < size; ++i)
     dst[i] = src[i];
 }
 
 template <typename T>
-inline bool array_cmp(const T *a1, const T *a2, size_t size) {
+inline bool array_cmp(const T* a1, const T* a2, size_t size) {
   for (auto i = 0; i < size; ++i)
-    if (a1[i] != a2[i]) return false;
+    if (a1[i] != a2[i])
+      return false;
   return true;
 }
 
 template <typename T, typename U>
-inline void array_set(T *arr, const U &val, size_t size) {
+inline void array_set(T* arr, const U& val, size_t size) {
   for (auto i = 0; i < size; ++i)
     arr[i] = static_cast<T>(val);
 }

--- a/include/ideep_pin_singletons.hpp
+++ b/include/ideep_pin_singletons.hpp
@@ -4,7 +4,6 @@
 #include "ideep.hpp"
 #include "mkldnn_compat.hpp"
 
-
 namespace ideep {
 
 engine& engine::cpu_engine() {
@@ -18,15 +17,16 @@ engine& engine::gpu_engine() {
 }
 
 struct RegisterEngineAllocator {
-  RegisterEngineAllocator(engine& eng,
-                          const std::function<void*(size_t)>& malloc,
-                          const std::function<void(void*)>& free) {
+  RegisterEngineAllocator(
+      engine& eng,
+      const std::function<void*(size_t)>& malloc,
+      const std::function<void(void*)>& free) {
     // change runtime flag start with "MKLDNN_" to "DNNL_"
     EnvSetter env_setter;
     eng.set_allocator(malloc, free);
   }
 };
 
-}
+} // namespace ideep
 
 #endif

--- a/include/mkldnn_compat.hpp
+++ b/include/mkldnn_compat.hpp
@@ -8,44 +8,44 @@
 #endif
 
 namespace ideep {
-  struct EnvSetter {
-    // oneDNN will only accept runtime flags which start with "DNNL_/ONEDNN_" from version v2.5.
-    // If user setting runtime flags start with MKLDNN_, we need to keep it works for a while before
-    // we finally deprecated it.
-    // This is a compatibility layer for runtime flags start with MKLDNN_
-    EnvSetter(){
-      for (auto name: mkldnn_runtime_flags){
-        query_and_set_env(name.c_str());
-      }
-    } 
+struct EnvSetter {
+  // oneDNN will only accept runtime flags which start with "DNNL_/ONEDNN_" from
+  // version v2.5. If user setting runtime flags start with MKLDNN_, we need to
+  // keep it works for a while before we finally deprecated it. This is a
+  // compatibility layer for runtime flags start with MKLDNN_
+  EnvSetter() {
+    for (auto name : mkldnn_runtime_flags) {
+      query_and_set_env(name.c_str());
+    }
+  }
 
-    void query_and_set_env(std::string name){
-      std::string value;
-      if (getenv_user(name, value)){
-        std::string dnnl_name = "DNNL_";
-        dnnl_name += std::string(name);
+  void query_and_set_env(std::string name) {
+    std::string value;
+    if (getenv_user(name, value)) {
+      std::string dnnl_name = "DNNL_";
+      dnnl_name += std::string(name);
 #ifdef _WIN32
-        SetEnvironmentVariable(dnnl_name.c_str(), value.c_str());
+      SetEnvironmentVariable(dnnl_name.c_str(), value.c_str());
 #else
-        setenv(dnnl_name.c_str(), value.c_str(), 1);
+      setenv(dnnl_name.c_str(), value.c_str(), 1);
 #endif
-      }
     }
+  }
 
-    bool getenv_user(std::string name, std::string& value) {
-        std::string name_str = "MKLDNN_" + std::string(name);
-        size_t value_length = 0;
-        const char* p = getenv(name_str.c_str());
-        value_length = p == nullptr ? 0 : strlen(p);
-        if (value_length > 0) {
-          value += std::string(p);
-          return true;
-        }
-        return false;
+  bool getenv_user(std::string name, std::string& value) {
+    std::string name_str = "MKLDNN_" + std::string(name);
+    size_t value_length = 0;
+    const char* p = getenv(name_str.c_str());
+    value_length = p == nullptr ? 0 : strlen(p);
+    if (value_length > 0) {
+      value += std::string(p);
+      return true;
     }
+    return false;
+  }
 
-    // current runtime flags in mkldnn
-    const std::vector<std::string> mkldnn_runtime_flags = {
+  // current runtime flags in mkldnn
+  const std::vector<std::string> mkldnn_runtime_flags = {
       "VERBOSE",
       "ITT_TASK_LEVEL",
       "PRIMITIVE_CACHE_CAPACITY",
@@ -55,12 +55,9 @@ namespace ideep {
       "VERBOSE_TIMESTAMP",
       "DEFAULT_FPMATH_MODE",
       "MAX_CPU_ISA",
-      "CPU_ISA_HINTS"
-    };
-  
-  };
+      "CPU_ISA_HINTS"};
+};
 
-}
+} // namespace ideep
 
 #endif
-


### PR DESCRIPTION
This PR aims to enable coding style formating for ideep. Clang-format is used as the major tool for coding format check and refactoring. 

- Added clang-format configuration file (copied from IPEX's clang-format file)
- Applied clang-format check and reformated all the ideep files as needed

Build test with Pytorch upstream together with test_mkldnn.py passed.