### PR TITLE
Merge conv/deconv/inner_product/matmul

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -24,10 +24,11 @@ struct attr_t : public dnnl::primitive_attr {
     set_fpmath_mode(mode);
   }
 
-  void set_fpmath_mode(dnnl_fpmath_mode_t mode) {
+  attr_t& set_fpmath_mode(dnnl_fpmath_mode_t mode) {
     error::wrap_c_api(
         dnnl_primitive_attr_set_fpmath_mode(get(), mode),
         "could not set fpmath mode primitive attribute");
+    return *this;
   }
 
   std::pair<scale_t, int> get_output_scales() const {

--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -12,8 +12,22 @@ using post_ops = dnnl::post_ops;
 struct attr_t : public dnnl::primitive_attr {
   attr_t() {}
 
+  attr_t(const attr_t& other) : dnnl::primitive_attr(other) {
+    *this = other;
+  }
+
   attr_t(int mask, const scale_t& scales) {
     set_output_scales(mask, scales);
+  }
+
+  attr_t(dnnl_fpmath_mode_t mode) {
+    set_fpmath_mode(mode);
+  }
+
+  void set_fpmath_mode(dnnl_fpmath_mode_t mode) {
+    error::wrap_c_api(
+        dnnl_primitive_attr_set_fpmath_mode(get(), mode),
+        "could not set fpmath mode primitive attribute");
   }
 
   std::pair<scale_t, int> get_output_scales() const {

--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -288,6 +288,41 @@ struct attr_t : public dnnl::primitive_attr {
     return true;
   }
 
+  attr_t& operator=(const attr_t& rhs) {
+    if (this == &rhs) {
+      return *this;
+    }
+    dnnl_primitive_attr_t result;
+    error::wrap_c_api(
+        dnnl_primitive_attr_clone(&result, rhs.get()),
+        "could not clone primitive attributes");
+    this->reset(result);
+    return *this;
+  }
+
+  bool operator==(const attr_t& rhs) const {
+    auto l_po = get_post_ops();
+    auto r_po = rhs.get_post_ops();
+    if (l_po.len() != r_po.len() ||
+        get_output_scales() != rhs.get_output_scales()) {
+      return false;
+    }
+    for (auto index = 0; index < l_po.len(); index++) {
+      kind l_akind, r_akind;
+      algorithm l_alg, r_alg;
+      float l_scale = 1.0, l_alpha = 1.0, l_beta = 0.0;
+      float r_scale = 1.0, r_alpha = 1.0, r_beta = 0.0;
+      std::tie(l_akind, l_scale, l_alpha, l_beta, l_alg) = get_params(index);
+      std::tie(r_akind, r_scale, r_alpha, r_beta, r_alg) =
+          rhs.get_params(index);
+      if (l_akind != r_akind || l_alg != r_alg || l_scale != r_scale ||
+          l_alpha != r_alpha || l_beta != r_beta) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   void to_bytes(utils::bytestring& bytes) const {
     // encode post ops
     auto num_ops = get_post_ops().len();

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -24,7 +24,8 @@ struct convolution_forward_params {
       : pd(std::move(pd)),
         primitive(std::move(primitive)),
         groups(groups),
-        bias_attr(attr_t()) {}
+        bias_attr(attr_t()),
+        pd_use_threads(omp_get_max_threads()) {}
 
   convolution_forward_params(
       dnnl::convolution_forward::primitive_desc&& pd,
@@ -34,12 +35,16 @@ struct convolution_forward_params {
       : pd(std::move(pd)),
         primitive(std::move(primitive)),
         groups(groups),
-        bias_attr(std::move(bias_attr)) {}
+        bias_attr(std::move(bias_attr)),
+        pd_use_threads(omp_get_max_threads()) {}
 
   dnnl::convolution_forward::primitive_desc pd;
   dnnl::convolution_forward primitive;
   int groups;
   attr_t bias_attr;
+  // From IPEX. Set in `do_prepare()`, only used outside ideep.
+  // TO-DO: Use a better name, i.e., num_threads
+  int pd_use_threads;
   // Param for static quantization
   std::shared_ptr<convolution_forward_quant_params> sq_param_ptr;
 
@@ -255,6 +260,7 @@ struct conv_deconv_utils {
     }
 
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    op_attr.set_fpmath_mode();
 
     dst_desc = attr.has_op_kind(kind::sum)
                     ? dst.get_desc()
@@ -766,16 +772,15 @@ struct convolution_forward
                       prop_kind aprop_kind = prop_kind::forward,
                       const lowp_kind alowp_kind = u8s8,
                       const engine& aengine = engine::cpu_engine()) {
+    // Consider fp32 only for IPEX
     if (bias.is_empty()) {
       compute_dispatch</*with_bias=*/false, true, true>(
           src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     } else {
       compute_dispatch</*with_bias=*/true, true, true>(
           src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     }
   }
 
@@ -798,11 +803,11 @@ struct convolution_forward
                       prop_kind aprop_kind = prop_kind::forward,
                       const lowp_kind alowp_kind = u8s8,
                       const engine& aengine = engine::cpu_engine()) {
+    // Consider fp32 only for IPEX
     static tensor dummy_bias;
     compute_dispatch</*with_bias=*/false, true, true>(
         src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        padding_l, padding_r, groups,attr, aalgorithm, aprop_kind, aengine);
   }
 
   // DEPRECATED
@@ -871,6 +876,40 @@ struct convolution_forward
         zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
+  // DEPRECATED
+  // compute with param and primitive. With bias
+  static void compute(
+      const convolution_forward_params& param,
+      const dnnl::convolution_forward& prim,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
+    (void)prim; // Mark as unused
+    if (bias.is_empty()) {
+      do_compute</*with_bias=*/false, true, true>(
+          param, src, weights, bias, dst);
+    } else {
+      do_compute</*with_bias=*/true, true, true>(
+          param, src, weights, bias, dst);
+    }
+  }
+
+  // DEPRECATED
+  // compute with param and primitive. Without bias
+  static void compute(
+      const convolution_forward_params& param,
+      const dnnl::convolution_forward& prim,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst) {
+    (void)prim; // Mark as unused
+    static tensor dummy_bias;
+    do_compute</*with_bias=*/false, true, true>(
+        param, src, weights, dummy_bias, dst);
+  }
+
+  template <bool is_channels_last = false>
   static tensor::desc expected_weights_desc(
       const dims& weights_dims,
       data_type dtype = data_type::f32,
@@ -884,10 +923,9 @@ struct convolution_forward
       data_type x_dtype = data_type::f32,
       const dims& src_dims = dims(),
       const attr_t& attr = attr_t(),
-      bool is_channels_last = false,
       const engine& aengine = engine::cpu_engine()) {
-
-    auto src_size = weights_dims.size(); // weights_dims is 4 for conv2d and 5 for conv3d
+    // weights_dims.size() is 3 for conv1d, 4 for conv2d and 5 for conv3d
+    auto src_size = weights_dims.size();
     auto grouped = groups > 1;
     auto weights_dims_g =
         grouped ? utils::group_dims(weights_dims, groups) : weights_dims;
@@ -905,52 +943,60 @@ struct convolution_forward
     auto oc = groups * dims_in[0 + grouped];
     if (5 == src_size) {
       kernel_size.push_back(dims_in[ndims - 3]);
+      kernel_size.push_back(dims_in[ndims - 2]);
+    } else if (4 == src_size) {
+      kernel_size.push_back(dims_in[ndims - 2]);
     }
-    kernel_size.push_back(dims_in[ndims - 2]);
     kernel_size.push_back(dims_in[ndims - 1]);
     if (src_dims.empty()) {
-      // Construct a dummy case
-      x_dims.push_back(1);
+      // Construct a dummy case. Shape from resnet50 model.
+      x_dims.push_back(32);
       x_dims.push_back(ic);
-      y_dims.push_back(1);
+      y_dims.push_back(32);
       y_dims.push_back(oc);
+      x_dims.push_back(14 * kernel_size[0]);
       if (4 == src_size) {
-        x_dims.push_back(4 * kernel_size[0]);
-        x_dims.push_back(4 * kernel_size[1]);
-      } else {
-        x_dims.push_back(8 * kernel_size[0]);
-        x_dims.push_back(8 * kernel_size[1]);
-        x_dims.push_back(8 * kernel_size[2]);
+        x_dims.push_back(14 * kernel_size[1]);
+      } else if (5 == src_size) {
+        x_dims.push_back(14 * kernel_size[1]);
+        x_dims.push_back(14 * kernel_size[2]);
       }
     } else {
       // Use the real data
-      for (auto i=0; i < src_size; ++i) {
+      for (auto i = 0; i < src_size; ++i) {
         x_dims.push_back(src_dims[i]);
       }
       y_dims.push_back(src_dims[0]);
       y_dims.push_back(oc);
     }
     for (auto d = 2; d < src_size; ++d) {
-      auto out_size = (x_dims[d] - ((kernel_size[d-2] - 1) * (dilates_[d-2] + 1) + 1)
-          + (padding_l[d-2] + padding_r[d-2])) / strides[d-2] + 1;
+      auto out_size =
+          (x_dims[d] - ((kernel_size[d - 2] - 1) * (dilates_[d - 2] + 1) + 1)
+          + (padding_l[d - 2] + padding_r[d - 2])) / strides[d - 2] + 1;
       y_dims.push_back(out_size);
     }
     x_dtype = dtype == data_type::bf16 ? dtype : x_dtype;
     auto y_dtype = dtype != data_type::s8 ? dtype : data_type::s32;
     tensor::desc src_desc(x_dims, x_dtype);
     tensor::desc dst_desc(y_dims, y_dtype);
-
     auto src_query = src_desc;
     auto dst_query = dst_desc;
     if (is_channels_last) {
-      if (src_size == 4) {
+      if (4 == src_size) {
         src_query = src_desc.to_format(tag::nhwc);
         dst_query = dst_desc.to_format(tag::nhwc);
-      } else if (src_size == 5) {
+      } else if (5 == src_size) {
         src_query = src_desc.to_format(tag::ndhwc);
         dst_query = dst_desc.to_format(tag::ndhwc);
+      } else if (3 == src_size) {
+        src_query = src_desc.to_format(tag::nwc);
+        dst_query = dst_desc.to_format(tag::nwc);
       }
     }
+    // if (3 == src_size) {
+    //   src_query = src_desc.to_format(tag::nwc);
+    //   dst_query = dst_desc.to_format(tag::nwc);
+    // }
 
     // FIXME: workaroud winograd format issue in inference
     // If prop_kind == forward_inference, the dnnl_wino_fmt for weights is
@@ -964,9 +1010,12 @@ struct convolution_forward
         aprop_kind == prop_kind::forward_inference) {
       apkind = prop_kind::forward;
     }
+    attr_t op_attr = attr;
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    op_attr.set_fpmath_mode();
     auto pd = get_primitive_desc</*with_bias=*/false>(
         src_query, weights_desc, tensor::desc(), dst_query, strides, dilates_,
-        padding_l, padding_r, attr, aalgorithm, apkind);
+        padding_l, padding_r, op_attr, aalgorithm, apkind);
 
     // embed group info into weights_desc
     return tensor::desc(pd.weights_desc(), groups);
@@ -998,23 +1047,18 @@ struct convolution_forward
 
     // For nhwc path, weight uses format_tag::any,
     // while activation uses format_tag::nhwc.
+    bool is_channels_last =
+        src_desc.is_channels_last() || weights_desc.is_channels_last();
     auto ndims = src_desc.get_dims().size();
-    if (ndims == 4) {
-      bool is_channels_last = src_desc.is_nhwc();
-      if (is_channels_last) {
-        src_desc_query = src_desc.to_format(tag::nhwc);
-        weights_desc_query = weights_desc.to_format_any();
-        bias_desc_query = with_bias ? bias_desc.to_format_any() : tensor::desc();
-        dst_desc_query = dst_desc.to_format(tag::nhwc);
+    if (is_channels_last) {
+      auto memory_format = tag::nhwc;
+      if (3 == ndims) {
+        memory_format = tag::nwc;
+      } else if (5 == ndims) {
+        memory_format = tag::ndhwc;
       }
-    } else if (ndims == 5) {
-      bool is_channels_last = src_desc.is_ndhwc();
-      if (is_channels_last) {
-        src_desc_query = src_desc.to_format(tag::ndhwc);
-        weights_desc_query = weights_desc.to_format_any();
-        bias_desc_query = with_bias ? bias_desc.to_format_any() : tensor::desc();
-        dst_desc_query = dst_desc.to_format(tag::ndhwc);
-      }
+      src_desc_query = src_desc.to_format(memory_format);
+      dst_desc_query = dst_desc.to_format(memory_format);
     }
 
     auto key = utils::create_key(
@@ -1314,24 +1358,38 @@ private:
       dst.reinit_if_possible(param.pd.dst_desc());
     }
     auto& primitive = param.primitive;
+    exec_args args;
+    args.insert({DNNL_ARG_SRC, expected_src});
+    args.insert({DNNL_ARG_WEIGHTS, expected_weights});
+    args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
+    args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point});
     if (with_bias) {
       auto& expected_bias = reorder_weight ?
           bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr) :
           bias;
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_BIAS, expected_bias},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point}});
+      args.insert({DNNL_ARG_BIAS, expected_bias});
+    }
+
+    // Deal with dst tensor
+    if (reorder_src) {
+      auto expected_dst_desc = param.pd.dst_desc();
+      tensor expected_dst;
+      // dst not init in FW or has same desc with expected desc.
+      if (dst.is_empty() || dst.get_desc() == expected_dst_desc) {
+        dst.reinit_if_possible(expected_dst_desc);
+        expected_dst = dst;
+      } else {
+        expected_dst.init(expected_dst_desc);
+      }
+      args.insert({DNNL_ARG_DST, expected_dst});
+      primitive.execute(stream::default_stream(), args);
+      // dst has been init in FW side, but has diff desc with expected_dst.
+      if (dst.get_desc() != expected_dst.get_desc()) {
+        dst.feed_from(expected_dst);
+      }
     } else {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point}});
+      args.insert({DNNL_ARG_DST, dst});
+      primitive.execute(stream::default_stream(), args);
     }
   }
 
@@ -1405,9 +1463,10 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
     auto weights_ = weights.make_grouped_weights(groups);
     auto dilates_ = utils::get_compatible_dilates(dilates);
 
-    bool is_nhwc = diff_dst.get_desc().is_nhwc();
-    bool is_ndhwc = diff_dst.get_desc().is_ndhwc();
-    auto format_tag = is_nhwc ? tag::nhwc : (is_ndhwc ? tag::ndhwc : tag::any);
+    bool channels_last = diff_dst.get_desc().is_channels_last();
+    auto format_tag = channels_last
+        ? (diff_src_dims.size() == 4 ? tag::nhwc : tag::ndhwc)
+        : tag::any;
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
     // align weight data type with diff_dst for bf16
     auto weights_desc =
@@ -1421,7 +1480,8 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
             diff_src_desc, weights_desc, tensor::desc(), diff_dst_desc, strides,
             dilates_, padding_l, padding_r);
 
-    auto op_attr = dnnl::primitive_attr();
+    auto op_attr = ideep::attr_t();
+    op_attr.set_fpmath_mode();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
@@ -1430,14 +1490,23 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
-    diff_src.reinit_if_possible(pd.diff_src_desc());
+
+    auto expected_diff_src_desc = pd.diff_src_desc();
+    tensor expected_diff_src;
+    // diff_src not init in FW or has same desc with expected desc.
+    if (diff_src.is_empty() || diff_src.get_desc() == expected_diff_src_desc) {
+      diff_src.reinit_if_possible(expected_diff_src_desc);
+      expected_diff_src = diff_src;
+    } else {
+      expected_diff_src.init(expected_diff_src_desc);
+    }
 
     tensor scratchpad(pd.scratchpad_desc());
 
     super(pd).execute(stream::default_stream(), 
                       {{DNNL_ARG_DIFF_DST, expected_diff_dst},
                        {DNNL_ARG_WEIGHTS, expected_weights},
-                       {DNNL_ARG_DIFF_SRC, diff_src},
+                       {DNNL_ARG_DIFF_SRC, expected_diff_src},
                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
@@ -1511,9 +1580,10 @@ struct convolution_backward_weights
         diff_weights_desc = diff_weights_desc.to_grouped(groups).to_format_any();
     }
 
-    bool is_nhwc = diff_dst.get_desc().is_nhwc();
-    bool is_ndhwc = diff_dst.get_desc().is_ndhwc();
-    auto format_tag = is_nhwc ? tag::nhwc : (is_ndhwc ? tag::ndhwc : tag::any);
+    bool channels_last = diff_dst.get_desc().is_channels_last();
+    auto format_tag = channels_last
+        ? (diff_dst.ndims() == 4 ? tag::nhwc : tag::ndhwc)
+        : tag::any;
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
     auto src_desc = src.get_desc().to_format(format_tag);
 
@@ -1532,7 +1602,8 @@ struct convolution_backward_weights
             dilates_, padding_l, padding_r, attr_t(), aalgorithm,
             prop_kind::forward, aengine);
 
-    auto op_attr = dnnl::primitive_attr();
+    auto op_attr = ideep::attr_t();
+    op_attr.set_fpmath_mode();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = with_diff_bias
@@ -1548,7 +1619,15 @@ struct convolution_backward_weights
     // embed group info into diff_weights_desc
     auto expected_diff_weights_desc =
         tensor::desc(pd.diff_weights_desc(), groups);
-    diff_weights.reinit_if_possible(expected_diff_weights_desc);
+    tensor expected_diff_weights;
+    // diff_weights not init in FW or has same desc with expected desc.
+    if (diff_weights.is_empty() ||
+        diff_weights.get_desc() == expected_diff_weights_desc) {
+      diff_weights.reinit_if_possible(expected_diff_weights_desc);
+      expected_diff_weights = diff_weights;
+    } else {
+      expected_diff_weights.init(expected_diff_weights_desc);
+    }
 
     tensor scratchpad(pd.scratchpad_desc());
 
@@ -1557,15 +1636,20 @@ struct convolution_backward_weights
       super(pd).execute(stream::default_stream(),
                         {{DNNL_ARG_DIFF_DST, expected_diff_dst},
                          {DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_DIFF_WEIGHTS, diff_weights},
+                         {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
                          {DNNL_ARG_DIFF_BIAS, diff_bias},
                          {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
       super(pd).execute(stream::default_stream(),
                         {{DNNL_ARG_DIFF_DST, expected_diff_dst},
                          {DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_DIFF_WEIGHTS, diff_weights},
+                         {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
                          {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    }
+    // diff_weights has been init in FW side, but has diff desc with
+    // expected_diff_weights.
+    if (diff_weights.get_desc() != expected_diff_weights_desc) {
+      diff_weights.feed_from(expected_diff_weights);
     }
   }
 };

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -6,7 +6,7 @@ struct convolution_forward_quant_params {
   convolution_forward_quant_params() {}
 
   convolution_forward_quant_params(tensor&& src_zero_point)
-                                  : src_zero_point(std::move(src_zero_point)) {}
+      : src_zero_point(std::move(src_zero_point)) {}
 
   // Due to oneDNN's mechanism of conv, zero point is set to
   // runtime value when weight is prepacked without input info in framework.
@@ -55,32 +55,33 @@ struct convolution_forward_params {
 struct conv_deconv_utils {
   // Common logic to prepare parameters for conv/deconv
   // quantization version
-  static void prepare_parameters(const tensor& src,
-                                 const tensor& weights,
-                                 const tensor& bias,
-                                 const dims& dst_dims,
-                                 const tensor& dst,
-                                 const dims& dilates,
-                                 int groups,
-                                 const scale_t& src_scales,
-                                 const scale_t& weights_scales,
-                                 const scale_t& dst_scales,
-                                 const zero_point_t& src_zero_points,
-                                 const zero_point_t& dst_zero_points,
-                                 const attr_t& attr,
-                                 const lowp_kind alowp_kind,
-                                 bool with_bias,
-                                 bool is_deconv,
-                                 tensor& weight_grouped, /* Output */
-                                 dims& dil_compatible, /* Output */
-                                 attr_t& op_attr, /* Output */
-                                 attr_t& src_attr, /* Output */
-                                 attr_t& weights_attr, /* Output */
-                                 attr_t& bias_attr, /* Output */
-                                 tensor::desc& src_desc, /* Output */
-                                 tensor::desc& weights_desc, /* Output */
-                                 tensor::desc& bias_desc, /* Output */
-                                 tensor::desc& dst_desc /* Output */) {
+  static void prepare_parameters(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      const tensor& dst,
+      const dims& dilates,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_points,
+      const zero_point_t& dst_zero_points,
+      const attr_t& attr,
+      const lowp_kind alowp_kind,
+      bool with_bias,
+      bool is_deconv,
+      tensor& weight_grouped, /* Output */
+      dims& dil_compatible, /* Output */
+      attr_t& op_attr, /* Output */
+      attr_t& src_attr, /* Output */
+      attr_t& weights_attr, /* Output */
+      attr_t& bias_attr, /* Output */
+      tensor::desc& src_desc, /* Output */
+      tensor::desc& weights_desc, /* Output */
+      tensor::desc& bias_desc, /* Output */
+      tensor::desc& dst_desc /* Output */) {
     scale_t dst_scales_in;
     data_type dst_data_type;
     op_attr = attr;
@@ -89,15 +90,16 @@ struct conv_deconv_utils {
     weight_grouped = weights.make_grouped_weights(groups, is_deconv);
     dil_compatible = utils::get_compatible_dilates(dilates);
 
-    auto& weights_scales_in =
-        weight_grouped.has_scale() ? weight_grouped.get_scale() : weights_scales;
+    auto& weights_scales_in = weight_grouped.has_scale()
+        ? weight_grouped.get_scale()
+        : weights_scales;
     if (!weights_scales_in.empty()) {
-      IDEEP_ENFORCE(alowp_kind == u8s8 || alowp_kind == s8s8,
-                    "Unsupported lowp kind");
+      IDEEP_ENFORCE(
+          alowp_kind == u8s8 || alowp_kind == s8s8, "Unsupported lowp kind");
       int scale_size = (weights_scales_in.size() > 1) ? dst_dims[1] : 1;
-      auto& src_scales_in =
-          src.has_scale() ? src.get_scale()
-                          : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
+      auto& src_scales_in = src.has_scale()
+          ? src.get_scale()
+          : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
 
       // determine dst data type
       if (dst.get_data_type() != data_type::undef) {
@@ -112,19 +114,24 @@ struct conv_deconv_utils {
 
       // fill primitive attr
       dst_scales_in = dst_scales.empty() || dst_data_type == data_type::f32
-                          ? IDEEP_DEF_SCALE
-                          : dst_scales;
+          ? IDEEP_DEF_SCALE
+          : dst_scales;
       const auto default_zero_point = zero_point_t(1);
-      const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
-                                   src_zero_points.empty() ? default_zero_point : src_zero_points;
-      const auto& weights_zero_point = weight_grouped.has_zero_point() ? weight_grouped.get_zero_point() : default_zero_point;
-      const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point() :
-                                   dst_zero_points.empty() ? default_zero_point : dst_zero_points;
+      const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point()
+          : src_zero_points.empty()                     ? default_zero_point
+                                                        : src_zero_points;
+      const auto& weights_zero_point = weight_grouped.has_zero_point()
+          ? weight_grouped.get_zero_point()
+          : default_zero_point;
+      const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point()
+          : dst_zero_points.empty()                     ? default_zero_point
+                                                        : dst_zero_points;
       const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
       const auto weights_zero_point_size = 1;
       const auto dst_zero_point_size = static_cast<dim>(dst_zero_point.size());
-      IDEEP_ENFORCE(src_zero_point_size == 1 && dst_zero_point_size == 1,
-                    "DNNL only support 1-dim zero_point");
+      IDEEP_ENFORCE(
+          src_zero_point_size == 1 && dst_zero_point_size == 1,
+          "DNNL only support 1-dim zero_point");
 
       scale_t bias_scales, op_scales;
       std::tie(bias_scales, op_scales) = utils::compute_scales(
@@ -143,41 +150,49 @@ struct conv_deconv_utils {
       zero_point_t src_zero_point_in_attr;
       int zp_mask = utils::tensor_zp_mask(1);
       attr.get_zero_points(DNNL_ARG_SRC, zp_mask, src_zero_point_in_attr);
-      if (src_zero_point_in_attr == zero_point_t({DNNL_RUNTIME_S32_VAL})) { // runtime src zero point
-        op_attr.set_zero_points(DNNL_ARG_SRC,
-                                zp_mask,
-                                src_zero_point_in_attr);
+      if (src_zero_point_in_attr ==
+          zero_point_t({DNNL_RUNTIME_S32_VAL})) { // runtime src zero point
+        op_attr.set_zero_points(DNNL_ARG_SRC, zp_mask, src_zero_point_in_attr);
       } else {
-        op_attr.set_zero_points(DNNL_ARG_SRC,
-                                ideep::utils::tensor_zp_mask(src_zero_point_size),
-                                src_zero_point);
+        op_attr.set_zero_points(
+            DNNL_ARG_SRC,
+            ideep::utils::tensor_zp_mask(src_zero_point_size),
+            src_zero_point);
       }
-      op_attr.set_zero_points(DNNL_ARG_WEIGHTS,
-                              ideep::utils::tensor_zp_mask(weights_zero_point_size),
-                              zero_point_t(1, weights_zero_point[0]));
+      op_attr.set_zero_points(
+          DNNL_ARG_WEIGHTS,
+          ideep::utils::tensor_zp_mask(weights_zero_point_size),
+          zero_point_t(1, weights_zero_point[0]));
       if (dst_data_type != data_type::f32) {
-        op_attr.set_zero_points(DNNL_ARG_DST,
-                                ideep::utils::tensor_zp_mask(dst_zero_point_size),
-                                dst_zero_point);
+        op_attr.set_zero_points(
+            DNNL_ARG_DST,
+            ideep::utils::tensor_zp_mask(dst_zero_point_size),
+            dst_zero_point);
       }
 
-      src_desc = {src.get_dims(),
-                  alowp_kind == u8s8 ? data_type::u8 : data_type::s8, tag::any};
+      src_desc = {
+          src.get_dims(),
+          alowp_kind == u8s8 ? data_type::u8 : data_type::s8,
+          tag::any};
       if (src.get_data_type() == data_type::f32) {
         src_attr = {0, src_scales_in};
       }
 
       weights_desc = weight_grouped.get_desc().to_type(data_type::s8);
       if (weight_grouped.get_data_type() == data_type::f32) {
-        weights_attr = {utils::tensor_scale_mask(scale_size, groups > 1),
-                        weights_scales_in};
+        weights_attr = {
+            utils::tensor_scale_mask(scale_size, groups > 1),
+            weights_scales_in};
       }
 
       if (with_bias) {
-        bias_desc = {bias.get_dims(), data_type::f32, tag::any}; // Use f32 instead of s32 to improve accuracy
+        bias_desc = {
+            bias.get_dims(),
+            data_type::f32,
+            tag::any}; // Use f32 instead of s32 to improve accuracy
         if (bias.get_data_type() == data_type::f32) {
-          bias_attr = {utils::tensor_scale_mask(scale_size, false),
-                        bias_scales};
+          bias_attr = {
+              utils::tensor_scale_mask(scale_size, false), bias_scales};
         }
       }
     } else {
@@ -187,20 +202,22 @@ struct conv_deconv_utils {
         src_attr = {0, src_scale};
       }
 
-      IDEEP_ENFORCE(utils::one_of(weight_grouped.get_data_type(),
-                                  data_type::f32, data_type::bf16),
-                    "Incorrect data type in weights");
+      IDEEP_ENFORCE(
+          utils::one_of(
+              weight_grouped.get_data_type(), data_type::f32, data_type::bf16),
+          "Incorrect data type in weights");
 
       // align weights data type with src
       dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
-                                                              : data_type::f32;
+                                                             : data_type::f32;
       src_desc = src.get_desc().to_type(dst_data_type);
       weights_desc = weight_grouped.get_desc().to_type(dst_data_type);
 
       if (with_bias) {
-        IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
-                                    data_type::f32, data_type::bf16),
-                      "Incorrect data type in bias");
+        IDEEP_ENFORCE(
+            utils::one_of(
+                bias.get_data_type(), data_type::f32, data_type::bf16),
+            "Incorrect data type in bias");
         bias_desc = bias.get_desc();
       }
     }
@@ -208,32 +225,33 @@ struct conv_deconv_utils {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     dst_desc = attr.has_op_kind(kind::sum)
-                    ? dst.get_desc()
-                    : tensor::desc(dst_dims, dst_data_type);
+        ? dst.get_desc()
+        : tensor::desc(dst_dims, dst_data_type);
   }
 
   // Common logic to prepare parameters for conv/deconv.
   // non-quantization version
-  static void prepare_parameters(const tensor& src,
-                                 const tensor& weights,
-                                 const tensor& bias,
-                                 const dims& dst_dims,
-                                 const tensor& dst,
-                                 const dims& dilates,
-                                 int groups,
-                                 const attr_t& attr,
-                                 bool with_bias,
-                                 bool is_deconv,
-                                 tensor& weight_grouped, /* Output */
-                                 dims& dil_compatible, /* Output */
-                                 attr_t& op_attr, /* Output */
-                                 attr_t& src_attr, /* Output */
-                                 attr_t& weights_attr, /* Output */
-                                 attr_t& bias_attr, /* Output */
-                                 tensor::desc& src_desc, /* Output */
-                                 tensor::desc& weights_desc, /* Output */
-                                 tensor::desc& bias_desc, /* Output */
-                                 tensor::desc& dst_desc /* Output */) {
+  static void prepare_parameters(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      const tensor& dst,
+      const dims& dilates,
+      int groups,
+      const attr_t& attr,
+      bool with_bias,
+      bool is_deconv,
+      tensor& weight_grouped, /* Output */
+      dims& dil_compatible, /* Output */
+      attr_t& op_attr, /* Output */
+      attr_t& src_attr, /* Output */
+      attr_t& weights_attr, /* Output */
+      attr_t& bias_attr, /* Output */
+      tensor::desc& src_desc, /* Output */
+      tensor::desc& weights_desc, /* Output */
+      tensor::desc& bias_desc, /* Output */
+      tensor::desc& dst_desc /* Output */) {
     scale_t dst_scales_in;
     data_type dst_data_type;
     op_attr = attr;
@@ -242,29 +260,29 @@ struct conv_deconv_utils {
     weight_grouped = weights.make_grouped_weights(groups, is_deconv);
     dil_compatible = utils::get_compatible_dilates(dilates);
 
-    IDEEP_ENFORCE(utils::one_of(weight_grouped.get_data_type(),
-                                data_type::f32, data_type::bf16),
-                  "Incorrect data type in weights");
+    IDEEP_ENFORCE(
+        utils::one_of(
+            weight_grouped.get_data_type(), data_type::f32, data_type::bf16),
+        "Incorrect data type in weights");
 
     // align weights data type with src
     dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
-                                                            : data_type::f32;
+                                                           : data_type::f32;
     src_desc = src.get_desc().to_type(dst_data_type);
     weights_desc = weight_grouped.get_desc().to_type(dst_data_type);
 
     if (with_bias) {
-      IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
-                                  data_type::f32, data_type::bf16),
-                    "Incorrect data type in bias");
+      IDEEP_ENFORCE(
+          utils::one_of(bias.get_data_type(), data_type::f32, data_type::bf16),
+          "Incorrect data type in bias");
       bias_desc = bias.get_desc();
     }
 
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    op_attr.set_fpmath_mode();
 
     dst_desc = attr.has_op_kind(kind::sum)
-                    ? dst.get_desc()
-                    : tensor::desc(dst_dims, dst_data_type);
+        ? dst.get_desc()
+        : tensor::desc(dst_dims, dst_data_type);
   }
 
   /// Get true zero point from input tensor, specified zero point or op attr
@@ -276,12 +294,13 @@ struct conv_deconv_utils {
   /// @param op_attr Attr of the conv/deconv operation.
   /// @param aengine Cpu execution engine.
   /// @param zero_point Output tensor of zero points.
-  static void obtain_runtime_zero_point(const tensor& input,
-                                        const zero_point_t& input_zero_point,
-                                        const int& arg_idx,
-                                        const dnnl::primitive_attr& op_attr,
-                                        const engine& aengine,
-                                        tensor& zero_point /* Output */) {
+  static void obtain_runtime_zero_point(
+      const tensor& input,
+      const zero_point_t& input_zero_point,
+      const int& arg_idx,
+      const dnnl::primitive_attr& op_attr,
+      const engine& aengine,
+      tensor& zero_point /* Output */) {
     zero_point_t src_zero_point_in_attr;
     int zp_mask = utils::tensor_zp_mask(1);
     op_attr.get_zero_points(arg_idx, zp_mask, src_zero_point_in_attr);
@@ -294,7 +313,8 @@ struct conv_deconv_utils {
     } else if (!input_zero_point.empty()) {
       src_zero_point_size = static_cast<dim>(input_zero_point.size());
       zero_point_data = &input_zero_point;
-    } else if (src_zero_point_in_attr == zero_point_t({DNNL_RUNTIME_S32_VAL}) ||
+    } else if (
+        src_zero_point_in_attr == zero_point_t({DNNL_RUNTIME_S32_VAL}) ||
         src_zero_point_in_attr.empty()) { // runtime zero point of input
       src_zero_point_size = static_cast<dim>(default_zero_point.size());
       zero_point_data = &default_zero_point;
@@ -302,19 +322,19 @@ struct conv_deconv_utils {
       src_zero_point_size = static_cast<dim>(src_zero_point_in_attr.size());
       zero_point_data = &src_zero_point_in_attr;
     }
-    tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, {1}};
+    tensor::desc src_zero_point_desc = {
+        {src_zero_point_size}, data_type::s32, {1}};
     zero_point.init(src_zero_point_desc, aengine);
-    auto src_z = reinterpret_cast<int32_t *>(zero_point.get_data_handle());
-    for (memory::dim i = 0; i < src_zero_point_size; ++i) // fill in zero point data
+    auto src_z = reinterpret_cast<int32_t*>(zero_point.get_data_handle());
+    for (memory::dim i = 0; i < src_zero_point_size;
+         ++i) // fill in zero point data
       src_z[i] = (*zero_point_data)[i];
-
   }
 };
 
 struct convolution_forward
     : public dnnl::convolution_forward,
       utils::computation_cache<dnnl::convolution_forward::primitive_desc> {
-
   using super = dnnl::convolution_forward;
 
   // 2-in-1 Conv computation with bias
@@ -323,28 +343,53 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_dispatch<false, reorder_src, reorder_weight>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     } else {
       compute_dispatch<true, reorder_src, reorder_weight>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     }
   }
 
@@ -354,23 +399,36 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const tensor& src,
-                      const tensor& weights,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_dispatch<false, reorder_src, reorder_weight>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
   }
 
   // 2-in-1 Quantized Conv computation with bias
@@ -379,36 +437,71 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const scale_t& src_scales,
-                      const scale_t& weights_scales,
-                      const scale_t& dst_scales,
-                      const zero_point_t& src_zero_point,
-                      const zero_point_t& dst_zero_point,
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_point,
+      const zero_point_t& dst_zero_point,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     } else {
       compute_dispatch</*with_bias=*/true, reorder_src, reorder_weight>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -418,59 +511,104 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const tensor& src,
-                      const tensor& weights,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const scale_t& src_scales,
-                      const scale_t& weights_scales,
-                      const scale_t& dst_scales,
-                      const zero_point_t& src_zero_point,
-                      const zero_point_t& dst_zero_point,
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_point,
+      const zero_point_t& dst_zero_point,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // 2-in-1 compute (prepare & compute) with bias
   // Bias is not used if it is empty.
   // This function is used to conv+binary fusion.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(const tensor &src,
-                             const tensor &other,
-                             const tensor &weights,
-                             const tensor &bias,
-                             const dims &dst_dims,
-                             tensor &dst,
-                             const dims &strides,
-                             const dims &dilates,
-                             const dims &padding_l,
-                             const dims &padding_r,
-                             int groups,
-                             const attr_t &attr = attr_t(),
-                             algorithm aalgorithm = algorithm::convolution_direct,
-                             prop_kind aprop_kind = prop_kind::forward,
-                             const engine &aengine = engine::cpu_engine()) {
+  static void compute_binary(
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_binary_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
-          src, other, weights, bias, dst_dims, dst, strides, dilates, padding_l,
-          padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          src,
+          other,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     } else {
       compute_binary_dispatch</*with_bias=*/true, reorder_src, reorder_weight>(
-          src, other, weights, bias, dst_dims, dst, strides, dilates, padding_l,
-          padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          src,
+          other,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     }
   }
 
@@ -478,141 +616,252 @@ struct convolution_forward
   // Bias is not used if it is empty.
   // This function is used to conv+binary fusion.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(const tensor &src,
-                             const tensor &other,
-                             const tensor &weights,
-                             const dims &dst_dims,
-                             tensor &dst,
-                             const dims &strides,
-                             const dims &dilates,
-                             const dims &padding_l,
-                             const dims &padding_r,
-                             int groups,
-                             const attr_t &attr = attr_t(),
-                             algorithm aalgorithm = algorithm::convolution_direct,
-                             prop_kind aprop_kind = prop_kind::forward,
-                             const engine &aengine = engine::cpu_engine()) {
+  static void compute_binary(
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_binary_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
-        src, other, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+        src,
+        other,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
   }
 
   // Conv prepare with bias for fp32
   // params will be initialized with PD/Primitive/groups ...
-  static void prepare(convolution_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      convolution_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare</*with_bias=*/false>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     } else {
       do_prepare</*with_bias=*/true>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     }
   }
 
   // Conv prepare w/o bias for fp32
   // params will be initialized with PD/Primitive/groups ...
-  static void prepare(convolution_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      convolution_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_prepare</*with_bias=*/false>(
-        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
   }
 
   // Conv prepare with bias for int8
   // params will be initialized with PD/Primitive/groups ...
   // quant_params will be initialized with quantization related info ...
-  static void prepare(convolution_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const scale_t& src_scales,
-                      const scale_t& weights_scales,
-                      const scale_t& dst_scales,
-                      const zero_point_t& src_zero_point,
-                      const zero_point_t& dst_zero_point,
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      convolution_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_point,
+      const zero_point_t& dst_zero_point,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare</*with_bias=*/false>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     } else {
       do_prepare</*with_bias=*/true>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     }
   }
 
   // Conv prepare w/o bias for int8
   // params will be initialized with PD/Primitive/groups ...
   // quant_params will be initialized with quantization related info ...
-  static void prepare(convolution_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const scale_t& src_scales,
-                      const scale_t& weights_scales,
-                      const scale_t& dst_scales,
-                      const zero_point_t& src_zero_point,
-                      const zero_point_t& dst_zero_point,
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      convolution_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_point,
+      const zero_point_t& dst_zero_point,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_prepare</*with_bias=*/false>(
-        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // Conv computation with pre-prepared params, with bias
@@ -623,11 +872,12 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const convolution_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst) {
+  static void compute(
+      const convolution_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     if (bias.is_empty()) {
       do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, weights, bias, dst);
@@ -645,10 +895,11 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const convolution_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      tensor& dst) {
+  static void compute(
+      const convolution_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst) {
     static tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -657,12 +908,13 @@ struct convolution_forward
   // Compute for binary post-op.
   // With bias. Bias is disabled if it is empty.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(const convolution_forward_params& param,
-                             const tensor& src,
-                             const tensor& other,
-                             const tensor& weights,
-                             const tensor& bias,
-                             tensor& dst) {
+  static void compute_binary(
+      const convolution_forward_params& param,
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     if (bias.is_empty()) {
       do_compute_binary</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, other, weights, bias, dst);
@@ -675,11 +927,12 @@ struct convolution_forward
   // Compute for binary post-op.
   // Without bias.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(const convolution_forward_params& param,
-                             const tensor& src,
-                             const tensor& other,
-                             const tensor& weights,
-                             tensor& dst) {
+  static void compute_binary(
+      const convolution_forward_params& param,
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      tensor& dst) {
     static tensor dummy_bias;
     do_compute_binary</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, other, weights, dummy_bias, dst);
@@ -689,125 +942,216 @@ struct convolution_forward
   // 2-in-1 compute (prepare & compute) with bias
   // Bias is not used if it is empty.
   // Zero points are passed explicitly as arguments for quantization
-  static void compute_v2(const tensor& src,
-                         const tensor& weights,
-                         const tensor& bias,
-                         const dims& dst_dims,
-                         tensor& dst,
-                         const dims& strides,
-                         const dims& dilates,
-                         const dims& padding_l,
-                         const dims& padding_r,
-                         int groups,
-                         const scale_t& src_scales = scale_t(),
-                         const scale_t& weights_scales = scale_t(),
-                         const scale_t& dst_scales = scale_t(),
-                         const zero_point_t& src_zero_point = zero_point_t(),
-                         const zero_point_t& dst_zero_point = zero_point_t(),
-                         const attr_t& attr = attr_t(),
-                         algorithm aalgorithm = algorithm::convolution_direct,
-                         prop_kind aprop_kind = prop_kind::forward,
-                         const lowp_kind alowp_kind = u8s8,
-                         const engine& aengine = engine::cpu_engine()) {
+  static void compute_v2(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const zero_point_t& src_zero_point = zero_point_t(),
+      const zero_point_t& dst_zero_point = zero_point_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_dispatch</*with_bias=*/false, true, true>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     } else {
       compute_dispatch</*with_bias=*/true, true, true>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     }
   }
 
   // DEPRECATED
   // 2-in-1 compute (prepare & compute) without bias
   // Zero points are passed explicitly as arguments for quantization
-  static void compute_v2(const tensor& src,
-                         const tensor& weights,
-                         const dims& dst_dims,
-                         tensor& dst,
-                         const dims& strides,
-                         const dims& dilates,
-                         const dims& padding_l,
-                         const dims& padding_r,
-                         int groups,
-                         const scale_t& src_scales = scale_t(),
-                         const scale_t& weights_scales = scale_t(),
-                         const scale_t& dst_scales = scale_t(),
-                         const zero_point_t& src_zero_point = zero_point_t(),
-                         const zero_point_t& dst_zero_point = zero_point_t(),
-                         const attr_t& attr = attr_t(),
-                         algorithm aalgorithm = algorithm::convolution_direct,
-                         prop_kind aprop_kind = prop_kind::forward,
-                         const lowp_kind alowp_kind = u8s8,
-                         const engine& aengine = engine::cpu_engine()) {
+  static void compute_v2(
+      const tensor& src,
+      const tensor& weights,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const zero_point_t& src_zero_point = zero_point_t(),
+      const zero_point_t& dst_zero_point = zero_point_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_dispatch</*with_bias=*/false, true, true>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // DEPRECATED
   // 2-in-1 compute (prepare & compute) with bias
   // Bias is not used if it is empty.
-  static void compute(const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const scale_t& src_scales = scale_t(),
-                      const scale_t& weights_scales = scale_t(),
-                      const scale_t& dst_scales = scale_t(),
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
     if (bias.is_empty()) {
       compute_dispatch</*with_bias=*/false, true, true>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     } else {
       compute_dispatch</*with_bias=*/true, true, true>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     }
   }
 
   // DEPRECATED
   // 2-in-1 compute (prepare & compute) without bias
-  static void compute(const tensor& src,
-                      const tensor& weights,
-                      const dims& dst_dims,
-                      tensor& dst,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      int groups,
-                      const scale_t& src_scales = scale_t(),
-                      const scale_t& weights_scales = scale_t(),
-                      const scale_t& dst_scales = scale_t(),
-                      const attr_t& attr = attr_t(),
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
     static tensor dummy_bias;
     compute_dispatch</*with_bias=*/false, true, true>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups,attr, aalgorithm, aprop_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
   }
 
   // DEPRECATED
@@ -836,14 +1180,50 @@ struct convolution_forward
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare</*with_bias=*/false>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          zero_point_t(),
+          zero_point_t(),
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     } else {
       do_prepare</*with_bias=*/true>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          zero_point_t(),
+          zero_point_t(),
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -871,9 +1251,27 @@ struct convolution_forward
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_prepare</*with_bias=*/false>(
-        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        zero_point_t(),
+        zero_point_t(),
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // DEPRECATED
@@ -971,8 +1369,10 @@ struct convolution_forward
     }
     for (auto d = 2; d < src_size; ++d) {
       auto out_size =
-          (x_dims[d] - ((kernel_size[d - 2] - 1) * (dilates_[d - 2] + 1) + 1)
-          + (padding_l[d - 2] + padding_r[d - 2])) / strides[d - 2] + 1;
+          (x_dims[d] - ((kernel_size[d - 2] - 1) * (dilates_[d - 2] + 1) + 1) +
+           (padding_l[d - 2] + padding_r[d - 2])) /
+              strides[d - 2] +
+          1;
       y_dims.push_back(out_size);
     }
     x_dtype = dtype == data_type::bf16 ? dtype : x_dtype;
@@ -1012,10 +1412,18 @@ struct convolution_forward
     }
     attr_t op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    op_attr.set_fpmath_mode();
     auto pd = get_primitive_desc</*with_bias=*/false>(
-        src_query, weights_desc, tensor::desc(), dst_query, strides, dilates_,
-        padding_l, padding_r, op_attr, aalgorithm, apkind);
+        src_query,
+        weights_desc,
+        tensor::desc(),
+        dst_query,
+        strides,
+        dilates_,
+        padding_l,
+        padding_r,
+        op_attr,
+        aalgorithm,
+        apkind);
 
     // embed group info into weights_desc
     return tensor::desc(pd.weights_desc(), groups);
@@ -1105,9 +1513,12 @@ struct convolution_forward
     });
   }
 
-private:
-  static bool use_gemm(const dims& src, const dims& weight, const dims& dst,
-                       int groups) {
+ private:
+  static bool use_gemm(
+      const dims& src,
+      const dims& weight,
+      const dims& dst,
+      int groups) {
     if (groups != 1)
       return false;
 
@@ -1143,25 +1554,52 @@ private:
       algorithm aalgorithm = algorithm::convolution_direct,
       prop_kind aprop_kind = prop_kind::forward,
       const engine& aengine = engine::cpu_engine()) {
-
     tensor::desc src_desc, weights_desc, bias_desc, dst_desc;
     attr_t op_attr, src_attr, weights_attr, bias_attr;
     tensor weights_grouped;
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src, weights, bias, dst_dims, dst, dilates, groups,
-        attr, with_bias, false, weights_grouped, dil_compatible,
-        op_attr, src_attr, weights_attr, bias_attr,
-        src_desc, weights_desc, bias_desc, dst_desc);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        dilates,
+        groups,
+        attr,
+        with_bias,
+        false,
+        weights_grouped,
+        dil_compatible,
+        op_attr,
+        src_attr,
+        weights_attr,
+        bias_attr,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc);
 
     // Used for to_mkldnn() path
     auto pd = get_primitive_desc<with_bias>(
-        src_desc, weights_desc, bias_desc, dst_desc, strides, dil_compatible,
-        padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        strides,
+        dil_compatible,
+        padding_l,
+        padding_r,
+        op_attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
     dnnl::convolution_forward primitive(pd);
-    convolution_forward_params params(std::move(pd), std::move(primitive), groups);
-    do_compute<with_bias, reorder_src, reorder_weight>(params, src, weights, bias, dst);
+    convolution_forward_params params(
+        std::move(pd), std::move(primitive), groups);
+    do_compute<with_bias, reorder_src, reorder_weight>(
+        params, src, weights, bias, dst);
   }
 
   // For int8
@@ -1187,7 +1625,6 @@ private:
       prop_kind aprop_kind = prop_kind::forward,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
-
     tensor::desc src_desc, weights_desc, bias_desc, dst_desc;
     attr_t op_attr, src_attr, weights_attr, bias_attr;
     tensor weights_grouped;
@@ -1195,51 +1632,106 @@ private:
     tensor src_zp_tensor;
 
     conv_deconv_utils::prepare_parameters(
-        src, weights, bias, dst_dims, dst, dilates, groups,
-        src_scales, weights_scales, dst_scales, src_zero_point, dst_zero_point,
-        attr, alowp_kind, with_bias, false,
-        weights_grouped, dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
-        src_desc, weights_desc, bias_desc, dst_desc);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        dilates,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        alowp_kind,
+        with_bias,
+        false,
+        weights_grouped,
+        dil_compatible,
+        op_attr,
+        src_attr,
+        weights_attr,
+        bias_attr,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc);
 
     // Used for to_mkldnn() path
     auto pd = get_primitive_desc<with_bias>(
-        src_desc, weights_desc, bias_desc, dst_desc, strides, dil_compatible,
-        padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        strides,
+        dil_compatible,
+        padding_l,
+        padding_r,
+        op_attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
     dnnl::convolution_forward primitive(pd);
     conv_deconv_utils::obtain_runtime_zero_point(
-      src, src_zero_point, DNNL_ARG_SRC, pd.get_primitive_attr(),
-      ideep::engine(pd.get_engine().get_kind()), src_zp_tensor);
+        src,
+        src_zero_point,
+        DNNL_ARG_SRC,
+        pd.get_primitive_attr(),
+        ideep::engine(pd.get_engine().get_kind()),
+        src_zp_tensor);
     convolution_forward_params params(
         std::move(pd), std::move(primitive), groups, std::move(bias_attr));
-    params.sq_param_ptr =
-        std::make_shared<convolution_forward_quant_params>(std::move(src_zp_tensor));
-    IDEEP_ENFORCE(params.sq_param_ptr, "Failed to allocate memory for parameters");
-    do_compute<with_bias, reorder_src, reorder_weight>(params, src, weights, bias, dst);
+    params.sq_param_ptr = std::make_shared<convolution_forward_quant_params>(
+        std::move(src_zp_tensor));
+    IDEEP_ENFORCE(
+        params.sq_param_ptr, "Failed to allocate memory for parameters");
+    do_compute<with_bias, reorder_src, reorder_weight>(
+        params, src, weights, bias, dst);
   }
 
   // For fp32 with binary post-op
   template <bool with_bias, bool reorder_src, bool reorder_weight>
   static void compute_binary_dispatch(
-      const tensor &src,
-      const tensor &other,
-      const tensor &weights,
-      const tensor &bias,
-      const dims &dst_dims,
-      tensor &dst,
-      const dims &strides,
-      const dims &dilates,
-      const dims &padding_l,
-      const dims &padding_r,
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
       int groups,
-      const attr_t &attr = attr_t(),
+      const attr_t& attr = attr_t(),
       algorithm aalgorithm = algorithm::convolution_direct,
       prop_kind aprop_kind = prop_kind::forward,
-      const engine &aengine = engine::cpu_engine()) {
+      const engine& aengine = engine::cpu_engine()) {
     convolution_forward_params params;
     do_prepare<with_bias>(
-        params, src, weights, bias, dst_dims, dst, strides, dilates, padding_l,
-        padding_r, groups, scale_t(), scale_t(), scale_t(), zero_point_t(),
-        zero_point_t(), attr, aalgorithm, aprop_kind, u8s8, aengine);
+        params,
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        scale_t(),
+        scale_t(),
+        scale_t(),
+        zero_point_t(),
+        zero_point_t(),
+        attr,
+        aalgorithm,
+        aprop_kind,
+        u8s8,
+        aengine);
     do_compute_binary<with_bias, reorder_src, reorder_weight>(
         params, src, other, weights, bias, dst);
   }
@@ -1268,14 +1760,40 @@ private:
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src, weights, bias, dst_dims, dst, dilates, groups,
-        attr, with_bias, false, weights_grouped, dil_compatible,
-        op_attr, src_attr, weights_attr, bias_attr,
-        src_desc, weights_desc, bias_desc, dst_desc);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        dilates,
+        groups,
+        attr,
+        with_bias,
+        false,
+        weights_grouped,
+        dil_compatible,
+        op_attr,
+        src_attr,
+        weights_attr,
+        bias_attr,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc);
 
     auto pd = get_primitive_desc<with_bias>(
-        src_desc, weights_desc, bias_desc, dst_desc, strides, dil_compatible,
-        padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        strides,
+        dil_compatible,
+        padding_l,
+        padding_r,
+        op_attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
 
     dnnl::convolution_forward primitive(pd);
 
@@ -1313,47 +1831,84 @@ private:
     tensor src_zp_tensor;
 
     conv_deconv_utils::prepare_parameters(
-        src, weights, bias, dst_dims, dst, dilates, groups,
-        src_scales, weights_scales, dst_scales, src_zero_point, dst_zero_point,
-        attr, alowp_kind, with_bias, false,
-        weights_grouped, dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
-        src_desc, weights_desc, bias_desc, dst_desc);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        dilates,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        alowp_kind,
+        with_bias,
+        false,
+        weights_grouped,
+        dil_compatible,
+        op_attr,
+        src_attr,
+        weights_attr,
+        bias_attr,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc);
 
     auto pd = get_primitive_desc<with_bias>(
-        src_desc, weights_desc, bias_desc, dst_desc, strides, dil_compatible,
-        padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        strides,
+        dil_compatible,
+        padding_l,
+        padding_r,
+        op_attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
 
     dnnl::convolution_forward primitive(pd);
 
     conv_deconv_utils::obtain_runtime_zero_point(
-      src, src_zero_point, DNNL_ARG_SRC, pd.get_primitive_attr(),
-      ideep::engine(pd.get_engine().get_kind()), src_zp_tensor);
+        src,
+        src_zero_point,
+        DNNL_ARG_SRC,
+        pd.get_primitive_attr(),
+        ideep::engine(pd.get_engine().get_kind()),
+        src_zp_tensor);
 
     param = {std::move(pd), std::move(primitive), groups, std::move(bias_attr)};
-    param.sq_param_ptr =
-        std::make_shared<convolution_forward_quant_params>(std::move(src_zp_tensor));
+    param.sq_param_ptr = std::make_shared<convolution_forward_quant_params>(
+        std::move(src_zp_tensor));
   }
 
   // do_compute with given primitive/pd, under the precondition
   // that whether or not src/weight/bias/dst need to be reorder
   // For both fp32 and int8
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void do_compute(const convolution_forward_params& param,
-                         const tensor& src,
-                         const tensor& weights,
-                         const tensor& bias,
-                         tensor& dst) {
+  static void do_compute(
+      const convolution_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     auto scratchpad = tensor(param.pd.scratchpad_desc());
     static tensor empty_src_zero_point;
-    auto& src_zero_point = param.sq_param_ptr ?
-        param.sq_param_ptr->src_zero_point : empty_src_zero_point;
+    auto& src_zero_point = param.sq_param_ptr
+        ? param.sq_param_ptr->src_zero_point
+        : empty_src_zero_point;
 
-    auto& expected_src = reorder_src ?
-        src.reorder_if_differ_in(param.pd.src_desc()) : src;
+    auto& expected_src =
+        reorder_src ? src.reorder_if_differ_in(param.pd.src_desc()) : src;
     auto&& grouped_weights = weights.make_grouped_weights(param.groups);
-    auto&& expected_weights = reorder_weight ?
-        grouped_weights.reorder_if_differ_in(param.pd.weights_desc()) :
-        grouped_weights;
+    auto&& expected_weights = reorder_weight
+        ? grouped_weights.reorder_if_differ_in(param.pd.weights_desc())
+        : grouped_weights;
     if (reorder_src) {
       dst.reinit_if_possible(param.pd.dst_desc());
     }
@@ -1364,9 +1919,9 @@ private:
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
     args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point});
     if (with_bias) {
-      auto& expected_bias = reorder_weight ?
-          bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr) :
-          bias;
+      auto& expected_bias = reorder_weight
+          ? bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr)
+          : bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
 
@@ -1395,70 +1950,71 @@ private:
 
   // For binary post-op
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void do_compute_binary(const convolution_forward_params &param,
-                                const tensor &src,
-                                const tensor &other,
-                                const tensor &weights,
-                                const tensor &bias,
-                                tensor &dst) {
-    auto &pd = param.pd;
+  static void do_compute_binary(
+      const convolution_forward_params& param,
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
+    auto& pd = param.pd;
     auto& primitive = param.primitive;
     auto scratchpad = tensor(pd.scratchpad_desc());
-    auto& expected_src = reorder_src ?
-        src.reorder_if_differ_in(pd.src_desc()) :
-        src;
+    auto& expected_src =
+        reorder_src ? src.reorder_if_differ_in(pd.src_desc()) : src;
     // make sure other has same format with dst.
     // TODO: other has different with dst?
-    auto& expected_other = reorder_src ?
-        other.reorder_if_differ_in(pd.dst_desc()) :
-        other;
+    auto& expected_other =
+        reorder_src ? other.reorder_if_differ_in(pd.dst_desc()) : other;
     auto&& grouped_weights = weights.make_grouped_weights(param.groups);
-    auto&& expected_weights = reorder_weight ?
-        grouped_weights.reorder_if_differ_in(pd.weights_desc()) :
-        grouped_weights;
+    auto&& expected_weights = reorder_weight
+        ? grouped_weights.reorder_if_differ_in(pd.weights_desc())
+        : grouped_weights;
     if (reorder_src) {
       dst.reinit_if_possible(pd.dst_desc());
     }
     if (with_bias) {
-      auto& expected_bias = reorder_weight ?
-          bias.reorder_if_differ_in(pd.bias_desc(), param.bias_attr) :
-          bias;
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_BIAS, expected_bias},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad},
-                         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
-                          expected_other}});
+      auto& expected_bias = reorder_weight
+          ? bias.reorder_if_differ_in(pd.bias_desc(), param.bias_attr)
+          : bias;
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_BIAS, expected_bias},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad},
+           {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
+            expected_other}});
     } else {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad},
-                         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
-                          expected_other}});
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad},
+           {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
+            expected_other}});
     }
   }
 };
 
-
 struct convolution_backward_data : public dnnl::convolution_backward_data {
-
   using super = dnnl::convolution_backward_data;
 
-  static void compute(const tensor& diff_dst,
-                      const tensor& weights,
-                      const dims& diff_src_dims,
-                      tensor& diff_src,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const int groups,
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& diff_dst,
+      const tensor& weights,
+      const dims& diff_src_dims,
+      tensor& diff_src,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      const int groups,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::convolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -1472,21 +2028,36 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
     auto weights_desc =
         weights_.get_desc().to_format_any().to_type(diff_dst.get_data_type());
 
-    auto diff_src_desc = 
+    auto diff_src_desc =
         tensor::desc(diff_src_dims, diff_dst_desc.get_data_type(), format_tag);
+
+    auto op_attr = attr;
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto forward_hints =
         convolution_forward::get_primitive_desc</*with_bias=*/false>(
-            diff_src_desc, weights_desc, tensor::desc(), diff_dst_desc, strides,
-            dilates_, padding_l, padding_r);
-
-    auto op_attr = ideep::attr_t();
-    op_attr.set_fpmath_mode();
-    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+            diff_src_desc,
+            weights_desc,
+            tensor::desc(),
+            diff_dst_desc,
+            strides,
+            dilates_,
+            padding_l,
+            padding_r,
+            op_attr);
 
     auto pd = primitive_desc(
-        {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
-         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
+        {aalgorithm,
+         diff_src_desc,
+         weights_desc,
+         diff_dst_desc,
+         strides,
+         dilates_,
+         padding_l,
+         padding_r},
+        op_attr,
+        aengine,
+        forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
@@ -1503,81 +2074,109 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(), 
-                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                       {DNNL_ARG_WEIGHTS, expected_weights},
-                       {DNNL_ARG_DIFF_SRC, expected_diff_src},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+         {DNNL_ARG_WEIGHTS, expected_weights},
+         {DNNL_ARG_DIFF_SRC, expected_diff_src},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
-
 struct convolution_backward_weights
     : public dnnl::convolution_backward_weights {
-
   using super = dnnl::convolution_backward_weights;
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      const dims& diff_weights_dims,
-                      tensor& diff_weights,
-                      tensor& diff_bias,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const int groups,
-                      const data_type diff_weight_type = data_type::undef,
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims,
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      const int groups,
+      const attr_t& attr = attr_t(),
+      const data_type diff_weight_type = data_type::undef,
+      algorithm aalgorithm = algorithm::convolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*with_diff_bias=*/true>(
-        src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
-        strides, dilates, padding_l, padding_r, groups, diff_weight_type, aalgorithm, aengine);
+        src,
+        diff_dst,
+        diff_weights_dims,
+        diff_weights,
+        diff_bias,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        diff_weight_type,
+        aalgorithm,
+        aengine);
   }
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      const dims& diff_weights_dims,
-                      tensor& diff_weights,
-                      const dims& strides,
-                      const dims& dilates,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const int groups,
-                      const data_type diff_weight_type = data_type::undef,
-                      algorithm aalgorithm = algorithm::convolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims,
+      tensor& diff_weights,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      const int groups,
+      const attr_t& attr = attr_t(),
+      const data_type diff_weight_type = data_type::undef,
+      algorithm aalgorithm = algorithm::convolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
-        src, diff_dst, diff_weights_dims, diff_weights, dummy_diff_bias,
-        strides, dilates, padding_l, padding_r, groups, diff_weight_type, aalgorithm, aengine);
+        src,
+        diff_dst,
+        diff_weights_dims,
+        diff_weights,
+        dummy_diff_bias,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        diff_weight_type,
+        aalgorithm,
+        aengine);
   }
 
  private:
   template <bool with_diff_bias>
-  static void compute_impl(const tensor& src,
-                           const tensor& diff_dst,
-                           const dims& diff_weights_dims,
-                           tensor& diff_weights,
-                           tensor& diff_bias,
-                           const dims& strides,
-                           const dims& dilates,
-                           const dims& padding_l,
-                           const dims& padding_r,
-                           const int groups,
-                           const data_type diff_weight_type,
-                           algorithm aalgorithm,
-                           const engine& aengine) {
-
+  static void compute_impl(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims,
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      const int groups,
+      const attr_t& attr,
+      const data_type diff_weight_type,
+      algorithm aalgorithm,
+      const engine& aengine) {
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
     data_type diff_dst_type = diff_dst.get_data_type();
-    data_type diff_weight_type_in = data_type::undef == diff_weight_type ?
-                                    diff_dst_type : diff_weight_type;
+    data_type diff_weight_type_in =
+        data_type::undef == diff_weight_type ? diff_dst_type : diff_weight_type;
     auto diff_weights_desc =
         tensor::desc(diff_weights_dims, diff_weight_type_in, tag::any);
     if (groups > 1) {
-        diff_weights_desc = diff_weights_desc.to_grouped(groups).to_format_any();
+      diff_weights_desc = diff_weights_desc.to_grouped(groups).to_format_any();
     }
 
     bool channels_last = diff_dst.get_desc().is_channels_last();
@@ -1587,7 +2186,7 @@ struct convolution_backward_weights
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
     auto src_desc = src.get_desc().to_format(format_tag);
 
-    auto diff_bias_desc =     
+    auto diff_bias_desc =
         tensor::desc({diff_dst.get_dim(1)}, diff_weight_type_in, tag::any);
 
     // for forward hint, weights_desc should have same data_type
@@ -1596,23 +2195,49 @@ struct convolution_backward_weights
     if (diff_weight_type_in != diff_dst_type) {
       weights_desc = weights_desc.to_type(diff_dst_type);
     }
-    auto forward_hints =
-        convolution_forward::get_primitive_desc<with_diff_bias>(
-            src_desc, weights_desc, diff_bias_desc, diff_dst_desc, strides,
-            dilates_, padding_l, padding_r, attr_t(), aalgorithm,
-            prop_kind::forward, aengine);
-
-    auto op_attr = ideep::attr_t();
-    op_attr.set_fpmath_mode();
+    auto op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    auto pd = with_diff_bias
-        ? primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_bias_desc, diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints)
-        : primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints);
+    auto forward_hints =
+        convolution_forward::get_primitive_desc<with_diff_bias>(
+            src_desc,
+            weights_desc,
+            diff_bias_desc,
+            diff_dst_desc,
+            strides,
+            dilates_,
+            padding_l,
+            padding_r,
+            op_attr,
+            aalgorithm,
+            prop_kind::forward,
+            aengine);
+
+    auto pd = with_diff_bias ? primitive_desc(
+                                   {aalgorithm,
+                                    src_desc,
+                                    diff_weights_desc,
+                                    diff_bias_desc,
+                                    diff_dst_desc,
+                                    strides,
+                                    dilates_,
+                                    padding_l,
+                                    padding_r},
+                                   op_attr,
+                                   aengine,
+                                   forward_hints)
+                             : primitive_desc(
+                                   {aalgorithm,
+                                    src_desc,
+                                    diff_weights_desc,
+                                    diff_dst_desc,
+                                    strides,
+                                    dilates_,
+                                    padding_l,
+                                    padding_r},
+                                   op_attr,
+                                   aengine,
+                                   forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
@@ -1633,18 +2258,20 @@ struct convolution_backward_weights
 
     if (with_diff_bias) {
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
-      super(pd).execute(stream::default_stream(),
-                        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                         {DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-                         {DNNL_ARG_DIFF_BIAS, diff_bias},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+           {DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+           {DNNL_ARG_DIFF_BIAS, diff_bias},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      super(pd).execute(stream::default_stream(),
-                        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                         {DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+           {DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
     // diff_weights has been init in FW side, but has diff desc with
     // expected_diff_weights.
@@ -1653,6 +2280,6 @@ struct convolution_backward_weights
     }
   }
 };
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -6,7 +6,7 @@ struct convolution_forward_quant_params {
   convolution_forward_quant_params() {}
 
   convolution_forward_quant_params(tensor&& src_zero_point)
-      : src_zero_point(std::move(src_zero_point)) {}
+                                  : src_zero_point(std::move(src_zero_point)) {}
 
   // Due to oneDNN's mechanism of conv, zero point is set to
   // runtime value when weight is prepacked without input info in framework.
@@ -117,8 +117,8 @@ struct conv_deconv_utils {
 
       // fill primitive attr
       dst_scales_in = dst_scales.empty() || dst_data_type == data_type::f32
-          ? IDEEP_DEF_SCALE
-          : dst_scales;
+                          ? IDEEP_DEF_SCALE
+                          : dst_scales;
       const auto default_zero_point = zero_point_t(1);
       const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
                                    src_zero_points.empty() ? default_zero_point : src_zero_points;
@@ -198,7 +198,7 @@ struct conv_deconv_utils {
 
       // align weights data type with src
       dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
-                                                             : data_type::f32;
+                                                              : data_type::f32;
       src_desc = src.get_desc().to_type(dst_data_type);
       weights_desc = weight_grouped.get_desc().to_type(dst_data_type);
 
@@ -213,8 +213,8 @@ struct conv_deconv_utils {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     dst_desc = attr.has_op_kind(kind::sum)
-        ? dst.get_desc()
-        : tensor::desc(dst_dims, dst_data_type);
+                    ? dst.get_desc()
+                    : tensor::desc(dst_dims, dst_data_type);
   }
 
   // Common logic to prepare parameters for conv/deconv.
@@ -267,8 +267,8 @@ struct conv_deconv_utils {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     dst_desc = attr.has_op_kind(kind::sum)
-        ? dst.get_desc()
-        : tensor::desc(dst_dims, dst_data_type);
+                    ? dst.get_desc()
+                    : tensor::desc(dst_dims, dst_data_type);
   }
 
   /// Get true zero point from input tensor, specified zero point or op attr
@@ -404,7 +404,7 @@ struct convolution_forward
                       const lowp_kind alowp_kind = u8s8,
                       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
+      compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
           src, weights, bias, dst_dims, dst, strides, dilates,
           padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
           src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
@@ -1104,7 +1104,7 @@ compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
     });
   }
 
- private:
+private:
   static bool use_gemm(const dims& src, const dims& weight, const dims& dst,
                        int groups) {
     if (groups != 1)
@@ -1206,7 +1206,7 @@ compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
         padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
     dnnl::convolution_forward primitive(pd);
     conv_deconv_utils::obtain_runtime_zero_point(
-        src, src_zero_point, DNNL_ARG_SRC, pd.get_primitive_attr(),
+      src, src_zero_point, DNNL_ARG_SRC, pd.get_primitive_attr(),
       ideep::engine(pd.get_engine().get_kind()), src_zp_tensor);
     convolution_forward_params params(
         std::move(pd), std::move(primitive), std::move(op_attr), groups, std::move(bias_attr));
@@ -1467,7 +1467,7 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
     auto weights_desc =
         weights_.get_desc().to_format_any().to_type(diff_dst.get_data_type());
 
-    auto diff_src_desc =
+    auto diff_src_desc = 
         tensor::desc(diff_src_dims, diff_dst_desc.get_data_type(), format_tag);
 
     auto op_attr = attr;
@@ -1574,7 +1574,7 @@ struct convolution_backward_weights
     auto diff_weights_desc =
         tensor::desc(diff_weights_dims, diff_weight_type_in, tag::any);
     if (groups > 1) {
-      diff_weights_desc = diff_weights_desc.to_grouped(groups).to_format_any();
+        diff_weights_desc = diff_weights_desc.to_grouped(groups).to_format_any();
     }
 
     bool channels_last = diff_dst.get_desc().is_channels_last();
@@ -1584,7 +1584,7 @@ struct convolution_backward_weights
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
     auto src_desc = src.get_desc().to_format(format_tag);
 
-    auto diff_bias_desc =
+    auto diff_bias_desc =     
         tensor::desc({diff_dst.get_dim(1)}, diff_weight_type_in, tag::any);
 
     // for forward hint, weights_desc should have same data_type
@@ -1631,16 +1631,16 @@ struct convolution_backward_weights
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
       super(pd).execute(stream::default_stream(),
                         {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                        {DNNL_ARG_SRC, expected_src},
-                        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-                        {DNNL_ARG_DIFF_BIAS, diff_bias},
-                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+                         {DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+                         {DNNL_ARG_DIFF_BIAS, diff_bias},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
       super(pd).execute(stream::default_stream(),
                         {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                        {DNNL_ARG_SRC, expected_src},
-                        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+                         {DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
     // diff_weights has been init in FW side, but has diff desc with
     // expected_diff_weights.

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -253,7 +253,7 @@ struct conv_deconv_utils {
 
     // align weights data type with src
     dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
-                                                           : data_type::f32;
+                                                            : data_type::f32;
     src_desc = src.get_desc().to_type(dst_data_type);
     weights_desc = weight_grouped.get_desc().to_type(dst_data_type);
 

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -60,33 +60,32 @@ struct convolution_forward_params {
 struct conv_deconv_utils {
   // Common logic to prepare parameters for conv/deconv
   // quantization version
-  static void prepare_parameters(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      const tensor& dst,
-      const dims& dilates,
-      int groups,
-      const scale_t& src_scales,
-      const scale_t& weights_scales,
-      const scale_t& dst_scales,
-      const zero_point_t& src_zero_points,
-      const zero_point_t& dst_zero_points,
-      const attr_t& attr,
-      const lowp_kind alowp_kind,
-      bool with_bias,
-      bool is_deconv,
-      tensor& weight_grouped, /* Output */
-      dims& dil_compatible, /* Output */
-      attr_t& op_attr, /* Output */
-      attr_t& src_attr, /* Output */
-      attr_t& weights_attr, /* Output */
-      attr_t& bias_attr, /* Output */
-      tensor::desc& src_desc, /* Output */
-      tensor::desc& weights_desc, /* Output */
-      tensor::desc& bias_desc, /* Output */
-      tensor::desc& dst_desc /* Output */) {
+  static void prepare_parameters(const tensor& src,
+                                 const tensor& weights,
+                                 const tensor& bias,
+                                 const dims& dst_dims,
+                                 const tensor& dst,
+                                 const dims& dilates,
+                                 int groups,
+                                 const scale_t& src_scales,
+                                 const scale_t& weights_scales,
+                                 const scale_t& dst_scales,
+                                 const zero_point_t& src_zero_points,
+                                 const zero_point_t& dst_zero_points,
+                                 const attr_t& attr,
+                                 const lowp_kind alowp_kind,
+                                 bool with_bias,
+                                 bool is_deconv,
+                                 tensor& weight_grouped, /* Output */
+                                 dims& dil_compatible, /* Output */
+                                 attr_t& op_attr, /* Output */
+                                 attr_t& src_attr, /* Output */
+                                 attr_t& weights_attr, /* Output */
+                                 attr_t& bias_attr, /* Output */
+                                 tensor::desc& src_desc, /* Output */
+                                 tensor::desc& weights_desc, /* Output */
+                                 tensor::desc& bias_desc, /* Output */
+                                 tensor::desc& dst_desc /* Output */) {
     scale_t dst_scales_in;
     data_type dst_data_type;
     op_attr = attr;
@@ -95,16 +94,15 @@ struct conv_deconv_utils {
     weight_grouped = weights.make_grouped_weights(groups, is_deconv);
     dil_compatible = utils::get_compatible_dilates(dilates);
 
-    auto& weights_scales_in = weight_grouped.has_scale()
-        ? weight_grouped.get_scale()
-        : weights_scales;
+    auto& weights_scales_in =
+        weight_grouped.has_scale() ? weight_grouped.get_scale() : weights_scales;
     if (!weights_scales_in.empty()) {
-      IDEEP_ENFORCE(
-          alowp_kind == u8s8 || alowp_kind == s8s8, "Unsupported lowp kind");
+      IDEEP_ENFORCE(alowp_kind == u8s8 || alowp_kind == s8s8,
+                    "Unsupported lowp kind");
       int scale_size = (weights_scales_in.size() > 1) ? dst_dims[1] : 1;
-      auto& src_scales_in = src.has_scale()
-          ? src.get_scale()
-          : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
+      auto& src_scales_in =
+          src.has_scale() ? src.get_scale()
+                          : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
 
       // determine dst data type
       if (dst.get_data_type() != data_type::undef) {
@@ -122,21 +120,16 @@ struct conv_deconv_utils {
           ? IDEEP_DEF_SCALE
           : dst_scales;
       const auto default_zero_point = zero_point_t(1);
-      const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point()
-          : src_zero_points.empty()                     ? default_zero_point
-                                                        : src_zero_points;
-      const auto& weights_zero_point = weight_grouped.has_zero_point()
-          ? weight_grouped.get_zero_point()
-          : default_zero_point;
-      const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point()
-          : dst_zero_points.empty()                     ? default_zero_point
-                                                        : dst_zero_points;
+      const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
+                                   src_zero_points.empty() ? default_zero_point : src_zero_points;
+      const auto& weights_zero_point = weight_grouped.has_zero_point() ? weight_grouped.get_zero_point() : default_zero_point;
+      const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point() :
+                                   dst_zero_points.empty() ? default_zero_point : dst_zero_points;
       const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
       const auto weights_zero_point_size = 1;
       const auto dst_zero_point_size = static_cast<dim>(dst_zero_point.size());
-      IDEEP_ENFORCE(
-          src_zero_point_size == 1 && dst_zero_point_size == 1,
-          "DNNL only support 1-dim zero_point");
+      IDEEP_ENFORCE(src_zero_point_size == 1 && dst_zero_point_size == 1,
+                    "DNNL only support 1-dim zero_point");
 
       scale_t bias_scales, op_scales;
       std::tie(bias_scales, op_scales) = utils::compute_scales(
@@ -155,49 +148,41 @@ struct conv_deconv_utils {
       zero_point_t src_zero_point_in_attr;
       int zp_mask = utils::tensor_zp_mask(1);
       attr.get_zero_points(DNNL_ARG_SRC, zp_mask, src_zero_point_in_attr);
-      if (src_zero_point_in_attr ==
-          zero_point_t({DNNL_RUNTIME_S32_VAL})) { // runtime src zero point
-        op_attr.set_zero_points(DNNL_ARG_SRC, zp_mask, src_zero_point_in_attr);
+      if (src_zero_point_in_attr == zero_point_t({DNNL_RUNTIME_S32_VAL})) { // runtime src zero point
+        op_attr.set_zero_points(DNNL_ARG_SRC,
+                                zp_mask,
+                                src_zero_point_in_attr);
       } else {
-        op_attr.set_zero_points(
-            DNNL_ARG_SRC,
-            ideep::utils::tensor_zp_mask(src_zero_point_size),
-            src_zero_point);
+        op_attr.set_zero_points(DNNL_ARG_SRC,
+                                ideep::utils::tensor_zp_mask(src_zero_point_size),
+                                src_zero_point);
       }
-      op_attr.set_zero_points(
-          DNNL_ARG_WEIGHTS,
-          ideep::utils::tensor_zp_mask(weights_zero_point_size),
-          zero_point_t(1, weights_zero_point[0]));
+      op_attr.set_zero_points(DNNL_ARG_WEIGHTS,
+                              ideep::utils::tensor_zp_mask(weights_zero_point_size),
+                              zero_point_t(1, weights_zero_point[0]));
       if (dst_data_type != data_type::f32) {
-        op_attr.set_zero_points(
-            DNNL_ARG_DST,
-            ideep::utils::tensor_zp_mask(dst_zero_point_size),
-            dst_zero_point);
+        op_attr.set_zero_points(DNNL_ARG_DST,
+                                ideep::utils::tensor_zp_mask(dst_zero_point_size),
+                                dst_zero_point);
       }
 
-      src_desc = {
-          src.get_dims(),
-          alowp_kind == u8s8 ? data_type::u8 : data_type::s8,
-          tag::any};
+      src_desc = {src.get_dims(),
+                  alowp_kind == u8s8 ? data_type::u8 : data_type::s8, tag::any};
       if (src.get_data_type() == data_type::f32) {
         src_attr = {0, src_scales_in};
       }
 
       weights_desc = weight_grouped.get_desc().to_type(data_type::s8);
       if (weight_grouped.get_data_type() == data_type::f32) {
-        weights_attr = {
-            utils::tensor_scale_mask(scale_size, groups > 1),
-            weights_scales_in};
+        weights_attr = {utils::tensor_scale_mask(scale_size, groups > 1),
+                        weights_scales_in};
       }
 
       if (with_bias) {
-        bias_desc = {
-            bias.get_dims(),
-            data_type::f32,
-            tag::any}; // Use f32 instead of s32 to improve accuracy
+        bias_desc = {bias.get_dims(), data_type::f32, tag::any}; // Use f32 instead of s32 to improve accuracy
         if (bias.get_data_type() == data_type::f32) {
-          bias_attr = {
-              utils::tensor_scale_mask(scale_size, false), bias_scales};
+          bias_attr = {utils::tensor_scale_mask(scale_size, false),
+                        bias_scales};
         }
       }
     } else {
@@ -207,10 +192,9 @@ struct conv_deconv_utils {
         src_attr = {0, src_scale};
       }
 
-      IDEEP_ENFORCE(
-          utils::one_of(
-              weight_grouped.get_data_type(), data_type::f32, data_type::bf16),
-          "Incorrect data type in weights");
+      IDEEP_ENFORCE(utils::one_of(weight_grouped.get_data_type(),
+                                  data_type::f32, data_type::bf16),
+                    "Incorrect data type in weights");
 
       // align weights data type with src
       dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
@@ -219,10 +203,9 @@ struct conv_deconv_utils {
       weights_desc = weight_grouped.get_desc().to_type(dst_data_type);
 
       if (with_bias) {
-        IDEEP_ENFORCE(
-            utils::one_of(
-                bias.get_data_type(), data_type::f32, data_type::bf16),
-            "Incorrect data type in bias");
+        IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
+                                    data_type::f32, data_type::bf16),
+                      "Incorrect data type in bias");
         bias_desc = bias.get_desc();
       }
     }
@@ -236,27 +219,26 @@ struct conv_deconv_utils {
 
   // Common logic to prepare parameters for conv/deconv.
   // non-quantization version
-  static void prepare_parameters(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      const tensor& dst,
-      const dims& dilates,
-      int groups,
-      const attr_t& attr,
-      bool with_bias,
-      bool is_deconv,
-      tensor& weight_grouped, /* Output */
-      dims& dil_compatible, /* Output */
-      attr_t& op_attr, /* Output */
-      attr_t& src_attr, /* Output */
-      attr_t& weights_attr, /* Output */
-      attr_t& bias_attr, /* Output */
-      tensor::desc& src_desc, /* Output */
-      tensor::desc& weights_desc, /* Output */
-      tensor::desc& bias_desc, /* Output */
-      tensor::desc& dst_desc /* Output */) {
+  static void prepare_parameters(const tensor& src,
+                                 const tensor& weights,
+                                 const tensor& bias,
+                                 const dims& dst_dims,
+                                 const tensor& dst,
+                                 const dims& dilates,
+                                 int groups,
+                                 const attr_t& attr,
+                                 bool with_bias,
+                                 bool is_deconv,
+                                 tensor& weight_grouped, /* Output */
+                                 dims& dil_compatible, /* Output */
+                                 attr_t& op_attr, /* Output */
+                                 attr_t& src_attr, /* Output */
+                                 attr_t& weights_attr, /* Output */
+                                 attr_t& bias_attr, /* Output */
+                                 tensor::desc& src_desc, /* Output */
+                                 tensor::desc& weights_desc, /* Output */
+                                 tensor::desc& bias_desc, /* Output */
+                                 tensor::desc& dst_desc /* Output */) {
     scale_t dst_scales_in;
     data_type dst_data_type;
     op_attr = attr;
@@ -265,10 +247,9 @@ struct conv_deconv_utils {
     weight_grouped = weights.make_grouped_weights(groups, is_deconv);
     dil_compatible = utils::get_compatible_dilates(dilates);
 
-    IDEEP_ENFORCE(
-        utils::one_of(
-            weight_grouped.get_data_type(), data_type::f32, data_type::bf16),
-        "Incorrect data type in weights");
+    IDEEP_ENFORCE(utils::one_of(weight_grouped.get_data_type(),
+                                data_type::f32, data_type::bf16),
+                  "Incorrect data type in weights");
 
     // align weights data type with src
     dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
@@ -277,9 +258,9 @@ struct conv_deconv_utils {
     weights_desc = weight_grouped.get_desc().to_type(dst_data_type);
 
     if (with_bias) {
-      IDEEP_ENFORCE(
-          utils::one_of(bias.get_data_type(), data_type::f32, data_type::bf16),
-          "Incorrect data type in bias");
+      IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
+                                  data_type::f32, data_type::bf16),
+                    "Incorrect data type in bias");
       bias_desc = bias.get_desc();
     }
 
@@ -299,13 +280,12 @@ struct conv_deconv_utils {
   /// @param op_attr Attr of the conv/deconv operation.
   /// @param aengine Cpu execution engine.
   /// @param zero_point Output tensor of zero points.
-  static void obtain_runtime_zero_point(
-      const tensor& input,
-      const zero_point_t& input_zero_point,
-      const int& arg_idx,
-      const dnnl::primitive_attr& op_attr,
-      const engine& aengine,
-      tensor& zero_point /* Output */) {
+  static void obtain_runtime_zero_point(const tensor& input,
+                                        const zero_point_t& input_zero_point,
+                                        const int& arg_idx,
+                                        const dnnl::primitive_attr& op_attr,
+                                        const engine& aengine,
+                                        tensor& zero_point /* Output */) {
     zero_point_t src_zero_point_in_attr;
     int zp_mask = utils::tensor_zp_mask(1);
     op_attr.get_zero_points(arg_idx, zp_mask, src_zero_point_in_attr);
@@ -318,8 +298,7 @@ struct conv_deconv_utils {
     } else if (!input_zero_point.empty()) {
       src_zero_point_size = static_cast<dim>(input_zero_point.size());
       zero_point_data = &input_zero_point;
-    } else if (
-        src_zero_point_in_attr == zero_point_t({DNNL_RUNTIME_S32_VAL}) ||
+    } else if (src_zero_point_in_attr == zero_point_t({DNNL_RUNTIME_S32_VAL}) ||
         src_zero_point_in_attr.empty()) { // runtime zero point of input
       src_zero_point_size = static_cast<dim>(default_zero_point.size());
       zero_point_data = &default_zero_point;
@@ -327,19 +306,19 @@ struct conv_deconv_utils {
       src_zero_point_size = static_cast<dim>(src_zero_point_in_attr.size());
       zero_point_data = &src_zero_point_in_attr;
     }
-    tensor::desc src_zero_point_desc = {
-        {src_zero_point_size}, data_type::s32, {1}};
+    tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, {1}};
     zero_point.init(src_zero_point_desc, aengine);
-    auto src_z = reinterpret_cast<int32_t*>(zero_point.get_data_handle());
-    for (memory::dim i = 0; i < src_zero_point_size;
-         ++i) // fill in zero point data
+    auto src_z = reinterpret_cast<int32_t *>(zero_point.get_data_handle());
+    for (memory::dim i = 0; i < src_zero_point_size; ++i) // fill in zero point data
       src_z[i] = (*zero_point_data)[i];
+
   }
 };
 
 struct convolution_forward
     : public dnnl::convolution_forward,
       utils::computation_cache<dnnl::convolution_forward::primitive_desc> {
+
   using super = dnnl::convolution_forward;
 
   // 2-in-1 Conv computation with bias
@@ -348,53 +327,28 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_dispatch<false, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     } else {
       compute_dispatch<true, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     }
   }
 
@@ -404,36 +358,23 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const tensor& src,
-      const tensor& weights,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& weights,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_dispatch<false, reorder_src, reorder_weight>(
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
   }
 
   // 2-in-1 Quantized Conv computation with bias
@@ -442,71 +383,36 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales,
-      const scale_t& weights_scales,
-      const scale_t& dst_scales,
-      const zero_point_t& src_zero_point,
-      const zero_point_t& dst_zero_point,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const scale_t& src_scales,
+                      const scale_t& weights_scales,
+                      const scale_t& dst_scales,
+                      const zero_point_t& src_zero_point,
+                      const zero_point_t& dst_zero_point,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const lowp_kind alowp_kind = u8s8,
+                      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     } else {
       compute_dispatch</*with_bias=*/true, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 
@@ -516,104 +422,59 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const tensor& src,
-      const tensor& weights,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales,
-      const scale_t& weights_scales,
-      const scale_t& dst_scales,
-      const zero_point_t& src_zero_point,
-      const zero_point_t& dst_zero_point,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& weights,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const scale_t& src_scales,
+                      const scale_t& weights_scales,
+                      const scale_t& dst_scales,
+                      const zero_point_t& src_zero_point,
+                      const zero_point_t& dst_zero_point,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const lowp_kind alowp_kind = u8s8,
+                      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        alowp_kind,
-        aengine);
+        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
   // 2-in-1 compute (prepare & compute) with bias
   // Bias is not used if it is empty.
   // This function is used to conv+binary fusion.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute_binary(const tensor &src,
+                             const tensor &other,
+                             const tensor &weights,
+                             const tensor &bias,
+                             const dims &dst_dims,
+                             tensor &dst,
+                             const dims &strides,
+                             const dims &dilates,
+                             const dims &padding_l,
+                             const dims &padding_r,
+                             int groups,
+                             const attr_t &attr = attr_t(),
+                             algorithm aalgorithm = algorithm::convolution_direct,
+                             prop_kind aprop_kind = prop_kind::forward,
+                             const engine &aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_binary_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
-          src,
-          other,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          src, other, weights, bias, dst_dims, dst, strides, dilates, padding_l,
+          padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     } else {
       compute_binary_dispatch</*with_bias=*/true, reorder_src, reorder_weight>(
-          src,
-          other,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          src, other, weights, bias, dst_dims, dst, strides, dilates, padding_l,
+          padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     }
   }
 
@@ -621,252 +482,141 @@ struct convolution_forward
   // Bias is not used if it is empty.
   // This function is used to conv+binary fusion.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute_binary(const tensor &src,
+                             const tensor &other,
+                             const tensor &weights,
+                             const dims &dst_dims,
+                             tensor &dst,
+                             const dims &strides,
+                             const dims &dilates,
+                             const dims &padding_l,
+                             const dims &padding_r,
+                             int groups,
+                             const attr_t &attr = attr_t(),
+                             algorithm aalgorithm = algorithm::convolution_direct,
+                             prop_kind aprop_kind = prop_kind::forward,
+                             const engine &aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_binary_dispatch</*with_bias=*/false, reorder_src, reorder_weight>(
-        src,
-        other,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        src, other, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
   }
 
   // Conv prepare with bias for fp32
   // params will be initialized with PD/Primitive/groups ...
-  static void prepare(
-      convolution_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(convolution_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare</*with_bias=*/false>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     } else {
       do_prepare</*with_bias=*/true>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     }
   }
 
   // Conv prepare w/o bias for fp32
   // params will be initialized with PD/Primitive/groups ...
-  static void prepare(
-      convolution_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(convolution_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_prepare</*with_bias=*/false>(
-        param,
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
   }
 
   // Conv prepare with bias for int8
   // params will be initialized with PD/Primitive/groups ...
   // quant_params will be initialized with quantization related info ...
-  static void prepare(
-      convolution_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales,
-      const scale_t& weights_scales,
-      const scale_t& dst_scales,
-      const zero_point_t& src_zero_point,
-      const zero_point_t& dst_zero_point,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(convolution_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const scale_t& src_scales,
+                      const scale_t& weights_scales,
+                      const scale_t& dst_scales,
+                      const zero_point_t& src_zero_point,
+                      const zero_point_t& dst_zero_point,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const lowp_kind alowp_kind = u8s8,
+                      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare</*with_bias=*/false>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     } else {
       do_prepare</*with_bias=*/true>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 
   // Conv prepare w/o bias for int8
   // params will be initialized with PD/Primitive/groups ...
   // quant_params will be initialized with quantization related info ...
-  static void prepare(
-      convolution_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales,
-      const scale_t& weights_scales,
-      const scale_t& dst_scales,
-      const zero_point_t& src_zero_point,
-      const zero_point_t& dst_zero_point,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(convolution_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const scale_t& src_scales,
+                      const scale_t& weights_scales,
+                      const scale_t& dst_scales,
+                      const zero_point_t& src_zero_point,
+                      const zero_point_t& dst_zero_point,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const lowp_kind alowp_kind = u8s8,
+                      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_prepare</*with_bias=*/false>(
-        param,
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        alowp_kind,
-        aengine);
+        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
   // Conv computation with pre-prepared params, with bias
@@ -877,12 +627,11 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const convolution_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
+  static void compute(const convolution_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst) {
     if (bias.is_empty()) {
       do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, weights, bias, dst);
@@ -900,11 +649,10 @@ struct convolution_forward
   // to false if src/weight/bias/dst are pre-reorded or no reorder needed as
   // you know for sure
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const convolution_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      tensor& dst) {
+  static void compute(const convolution_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      tensor& dst) {
     static tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -913,13 +661,12 @@ struct convolution_forward
   // Compute for binary post-op.
   // With bias. Bias is disabled if it is empty.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(
-      const convolution_forward_params& param,
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
+  static void compute_binary(const convolution_forward_params& param,
+                             const tensor& src,
+                             const tensor& other,
+                             const tensor& weights,
+                             const tensor& bias,
+                             tensor& dst) {
     if (bias.is_empty()) {
       do_compute_binary</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, other, weights, bias, dst);
@@ -932,12 +679,11 @@ struct convolution_forward
   // Compute for binary post-op.
   // Without bias.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(
-      const convolution_forward_params& param,
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      tensor& dst) {
+  static void compute_binary(const convolution_forward_params& param,
+                             const tensor& src,
+                             const tensor& other,
+                             const tensor& weights,
+                             tensor& dst) {
     static tensor dummy_bias;
     do_compute_binary</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, other, weights, dummy_bias, dst);
@@ -947,216 +693,125 @@ struct convolution_forward
   // 2-in-1 compute (prepare & compute) with bias
   // Bias is not used if it is empty.
   // Zero points are passed explicitly as arguments for quantization
-  static void compute_v2(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales = scale_t(),
-      const scale_t& weights_scales = scale_t(),
-      const scale_t& dst_scales = scale_t(),
-      const zero_point_t& src_zero_point = zero_point_t(),
-      const zero_point_t& dst_zero_point = zero_point_t(),
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute_v2(const tensor& src,
+                         const tensor& weights,
+                         const tensor& bias,
+                         const dims& dst_dims,
+                         tensor& dst,
+                         const dims& strides,
+                         const dims& dilates,
+                         const dims& padding_l,
+                         const dims& padding_r,
+                         int groups,
+                         const scale_t& src_scales = scale_t(),
+                         const scale_t& weights_scales = scale_t(),
+                         const scale_t& dst_scales = scale_t(),
+                         const zero_point_t& src_zero_point = zero_point_t(),
+                         const zero_point_t& dst_zero_point = zero_point_t(),
+                         const attr_t& attr = attr_t(),
+                         algorithm aalgorithm = algorithm::convolution_direct,
+                         prop_kind aprop_kind = prop_kind::forward,
+                         const lowp_kind alowp_kind = u8s8,
+                         const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_dispatch</*with_bias=*/false, true, true>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     } else {
       compute_dispatch</*with_bias=*/true, true, true>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 
   // DEPRECATED
   // 2-in-1 compute (prepare & compute) without bias
   // Zero points are passed explicitly as arguments for quantization
-  static void compute_v2(
-      const tensor& src,
-      const tensor& weights,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales = scale_t(),
-      const scale_t& weights_scales = scale_t(),
-      const scale_t& dst_scales = scale_t(),
-      const zero_point_t& src_zero_point = zero_point_t(),
-      const zero_point_t& dst_zero_point = zero_point_t(),
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute_v2(const tensor& src,
+                         const tensor& weights,
+                         const dims& dst_dims,
+                         tensor& dst,
+                         const dims& strides,
+                         const dims& dilates,
+                         const dims& padding_l,
+                         const dims& padding_r,
+                         int groups,
+                         const scale_t& src_scales = scale_t(),
+                         const scale_t& weights_scales = scale_t(),
+                         const scale_t& dst_scales = scale_t(),
+                         const zero_point_t& src_zero_point = zero_point_t(),
+                         const zero_point_t& dst_zero_point = zero_point_t(),
+                         const attr_t& attr = attr_t(),
+                         algorithm aalgorithm = algorithm::convolution_direct,
+                         prop_kind aprop_kind = prop_kind::forward,
+                         const lowp_kind alowp_kind = u8s8,
+                         const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_dispatch</*with_bias=*/false, true, true>(
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        alowp_kind,
-        aengine);
+        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
   // DEPRECATED
   // 2-in-1 compute (prepare & compute) with bias
   // Bias is not used if it is empty.
-  static void compute(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales = scale_t(),
-      const scale_t& weights_scales = scale_t(),
-      const scale_t& dst_scales = scale_t(),
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const scale_t& src_scales = scale_t(),
+                      const scale_t& weights_scales = scale_t(),
+                      const scale_t& dst_scales = scale_t(),
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const lowp_kind alowp_kind = u8s8,
+                      const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
     if (bias.is_empty()) {
       compute_dispatch</*with_bias=*/false, true, true>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     } else {
       compute_dispatch</*with_bias=*/true, true, true>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 
   // DEPRECATED
   // 2-in-1 compute (prepare & compute) without bias
-  static void compute(
-      const tensor& src,
-      const tensor& weights,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales = scale_t(),
-      const scale_t& weights_scales = scale_t(),
-      const scale_t& dst_scales = scale_t(),
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& weights,
+                      const dims& dst_dims,
+                      tensor& dst,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      int groups,
+                      const scale_t& src_scales = scale_t(),
+                      const scale_t& weights_scales = scale_t(),
+                      const scale_t& dst_scales = scale_t(),
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      prop_kind aprop_kind = prop_kind::forward,
+                      const lowp_kind alowp_kind = u8s8,
+                      const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
     static tensor dummy_bias;
     compute_dispatch</*with_bias=*/false, true, true>(
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
   // DEPRECATED
@@ -1185,50 +840,14 @@ struct convolution_forward
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare</*with_bias=*/false>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          zero_point_t(),
-          zero_point_t(),
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     } else {
       do_prepare</*with_bias=*/true>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          zero_point_t(),
-          zero_point_t(),
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 
@@ -1256,27 +875,9 @@ struct convolution_forward
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_prepare</*with_bias=*/false>(
-        param,
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        zero_point_t(),
-        zero_point_t(),
-        attr,
-        aalgorithm,
-        aprop_kind,
-        alowp_kind,
-        aengine);
+        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+        zero_point_t(), zero_point_t(), attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
   // DEPRECATED
@@ -1366,24 +967,22 @@ struct convolution_forward
       }
     } else {
       // Use the real data
-      for (auto i = 0; i < src_size; ++i) {
+      for (auto i=0; i < src_size; ++i) {
         x_dims.push_back(src_dims[i]);
       }
       y_dims.push_back(src_dims[0]);
       y_dims.push_back(oc);
     }
     for (auto d = 2; d < src_size; ++d) {
-      auto out_size =
-          (x_dims[d] - ((kernel_size[d - 2] - 1) * (dilates_[d - 2] + 1) + 1) +
-           (padding_l[d - 2] + padding_r[d - 2])) /
-              strides[d - 2] +
-          1;
+      auto out_size = (x_dims[d] - ((kernel_size[d-2] - 1) * (dilates_[d-2] + 1) + 1)
+          + (padding_l[d-2] + padding_r[d-2])) / strides[d-2] + 1;
       y_dims.push_back(out_size);
     }
     x_dtype = dtype == data_type::bf16 ? dtype : x_dtype;
     auto y_dtype = dtype != data_type::s8 ? dtype : data_type::s32;
     tensor::desc src_desc(x_dims, x_dtype);
     tensor::desc dst_desc(y_dims, y_dtype);
+
     auto src_query = src_desc;
     auto dst_query = dst_desc;
     if (is_channels_last) {
@@ -1398,10 +997,6 @@ struct convolution_forward
         dst_query = dst_desc.to_format(tag::nwc);
       }
     }
-    // if (3 == src_size) {
-    //   src_query = src_desc.to_format(tag::nwc);
-    //   dst_query = dst_desc.to_format(tag::nwc);
-    // }
 
     // FIXME: workaroud winograd format issue in inference
     // If prop_kind == forward_inference, the dnnl_wino_fmt for weights is
@@ -1418,17 +1013,8 @@ struct convolution_forward
     attr_t op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto pd = get_primitive_desc</*with_bias=*/false>(
-        src_query,
-        weights_desc,
-        tensor::desc(),
-        dst_query,
-        strides,
-        dilates_,
-        padding_l,
-        padding_r,
-        op_attr,
-        aalgorithm,
-        apkind);
+        src_query, weights_desc, tensor::desc(), dst_query, strides, dilates_,
+        padding_l, padding_r, op_attr, aalgorithm, apkind);
 
     // embed group info into weights_desc
     return tensor::desc(pd.weights_desc(), groups);
@@ -1519,11 +1105,8 @@ struct convolution_forward
   }
 
  private:
-  static bool use_gemm(
-      const dims& src,
-      const dims& weight,
-      const dims& dst,
-      int groups) {
+  static bool use_gemm(const dims& src, const dims& weight, const dims& dst,
+                       int groups) {
     if (groups != 1)
       return false;
 
@@ -1559,52 +1142,25 @@ struct convolution_forward
       algorithm aalgorithm = algorithm::convolution_direct,
       prop_kind aprop_kind = prop_kind::forward,
       const engine& aengine = engine::cpu_engine()) {
+
     tensor::desc src_desc, weights_desc, bias_desc, dst_desc;
     attr_t op_attr, src_attr, weights_attr, bias_attr;
     tensor weights_grouped;
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        dilates,
-        groups,
-        attr,
-        with_bias,
-        false,
-        weights_grouped,
-        dil_compatible,
-        op_attr,
-        src_attr,
-        weights_attr,
-        bias_attr,
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc);
+        src, weights, bias, dst_dims, dst, dilates, groups,
+        attr, with_bias, false, weights_grouped, dil_compatible,
+        op_attr, src_attr, weights_attr, bias_attr,
+        src_desc, weights_desc, bias_desc, dst_desc);
 
     // Used for to_mkldnn() path
     auto pd = get_primitive_desc<with_bias>(
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        strides,
-        dil_compatible,
-        padding_l,
-        padding_r,
-        op_attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        src_desc, weights_desc, bias_desc, dst_desc, strides, dil_compatible,
+        padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
     dnnl::convolution_forward primitive(pd);
-    convolution_forward_params params(
-        std::move(pd), std::move(primitive), std::move(op_attr), groups);
-    do_compute<with_bias, reorder_src, reorder_weight>(
-        params, src, weights, bias, dst);
+    convolution_forward_params params(std::move(pd), std::move(primitive), std::move(op_attr), groups);
+    do_compute<with_bias, reorder_src, reorder_weight>(params, src, weights, bias, dst);
   }
 
   // For int8
@@ -1630,6 +1186,7 @@ struct convolution_forward
       prop_kind aprop_kind = prop_kind::forward,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
+
     tensor::desc src_desc, weights_desc, bias_desc, dst_desc;
     attr_t op_attr, src_attr, weights_attr, bias_attr;
     tensor weights_grouped;
@@ -1637,110 +1194,51 @@ struct convolution_forward
     tensor src_zp_tensor;
 
     conv_deconv_utils::prepare_parameters(
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        dilates,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        alowp_kind,
-        with_bias,
-        false,
-        weights_grouped,
-        dil_compatible,
-        op_attr,
-        src_attr,
-        weights_attr,
-        bias_attr,
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc);
+        src, weights, bias, dst_dims, dst, dilates, groups,
+        src_scales, weights_scales, dst_scales, src_zero_point, dst_zero_point,
+        attr, alowp_kind, with_bias, false,
+        weights_grouped, dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
+        src_desc, weights_desc, bias_desc, dst_desc);
 
     // Used for to_mkldnn() path
     auto pd = get_primitive_desc<with_bias>(
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        strides,
-        dil_compatible,
-        padding_l,
-        padding_r,
-        op_attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        src_desc, weights_desc, bias_desc, dst_desc, strides, dil_compatible,
+        padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
     dnnl::convolution_forward primitive(pd);
     conv_deconv_utils::obtain_runtime_zero_point(
-        src,
-        src_zero_point,
-        DNNL_ARG_SRC,
-        pd.get_primitive_attr(),
-        ideep::engine(pd.get_engine().get_kind()),
-        src_zp_tensor);
+        src, src_zero_point, DNNL_ARG_SRC, pd.get_primitive_attr(),
+      ideep::engine(pd.get_engine().get_kind()), src_zp_tensor);
     convolution_forward_params params(
-        std::move(pd),
-        std::move(primitive),
-        std::move(op_attr),
-        groups,
-        std::move(bias_attr));
-    params.sq_param_ptr = std::make_shared<convolution_forward_quant_params>(
-        std::move(src_zp_tensor));
-    IDEEP_ENFORCE(
-        params.sq_param_ptr, "Failed to allocate memory for parameters");
-    do_compute<with_bias, reorder_src, reorder_weight>(
-        params, src, weights, bias, dst);
+        std::move(pd), std::move(primitive), std::move(op_attr), groups, std::move(bias_attr));
+    params.sq_param_ptr =
+        std::make_shared<convolution_forward_quant_params>(std::move(src_zp_tensor));
+    IDEEP_ENFORCE(params.sq_param_ptr, "Failed to allocate memory for parameters");
+    do_compute<with_bias, reorder_src, reorder_weight>(params, src, weights, bias, dst);
   }
 
   // For fp32 with binary post-op
   template <bool with_bias, bool reorder_src, bool reorder_weight>
   static void compute_binary_dispatch(
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
+      const tensor &src,
+      const tensor &other,
+      const tensor &weights,
+      const tensor &bias,
+      const dims &dst_dims,
+      tensor &dst,
+      const dims &strides,
+      const dims &dilates,
+      const dims &padding_l,
+      const dims &padding_r,
       int groups,
-      const attr_t& attr = attr_t(),
+      const attr_t &attr = attr_t(),
       algorithm aalgorithm = algorithm::convolution_direct,
       prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+      const engine &aengine = engine::cpu_engine()) {
     convolution_forward_params params;
     do_prepare<with_bias>(
-        params,
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        scale_t(),
-        scale_t(),
-        scale_t(),
-        zero_point_t(),
-        zero_point_t(),
-        attr,
-        aalgorithm,
-        aprop_kind,
-        u8s8,
-        aengine);
+        params, src, weights, bias, dst_dims, dst, strides, dilates, padding_l,
+        padding_r, groups, scale_t(), scale_t(), scale_t(), zero_point_t(),
+        zero_point_t(), attr, aalgorithm, aprop_kind, u8s8, aengine);
     do_compute_binary<with_bias, reorder_src, reorder_weight>(
         params, src, other, weights, bias, dst);
   }
@@ -1769,40 +1267,14 @@ struct convolution_forward
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        dilates,
-        groups,
-        attr,
-        with_bias,
-        false,
-        weights_grouped,
-        dil_compatible,
-        op_attr,
-        src_attr,
-        weights_attr,
-        bias_attr,
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc);
+        src, weights, bias, dst_dims, dst, dilates, groups,
+        attr, with_bias, false, weights_grouped, dil_compatible,
+        op_attr, src_attr, weights_attr, bias_attr,
+        src_desc, weights_desc, bias_desc, dst_desc);
 
     auto pd = get_primitive_desc<with_bias>(
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        strides,
-        dil_compatible,
-        padding_l,
-        padding_r,
-        op_attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        src_desc, weights_desc, bias_desc, dst_desc, strides, dil_compatible,
+        padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
 
     dnnl::convolution_forward primitive(pd);
 
@@ -1840,92 +1312,47 @@ struct convolution_forward
     tensor src_zp_tensor;
 
     conv_deconv_utils::prepare_parameters(
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        dilates,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        alowp_kind,
-        with_bias,
-        false,
-        weights_grouped,
-        dil_compatible,
-        op_attr,
-        src_attr,
-        weights_attr,
-        bias_attr,
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc);
+        src, weights, bias, dst_dims, dst, dilates, groups,
+        src_scales, weights_scales, dst_scales, src_zero_point, dst_zero_point,
+        attr, alowp_kind, with_bias, false,
+        weights_grouped, dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
+        src_desc, weights_desc, bias_desc, dst_desc);
 
     auto pd = get_primitive_desc<with_bias>(
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        strides,
-        dil_compatible,
-        padding_l,
-        padding_r,
-        op_attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        src_desc, weights_desc, bias_desc, dst_desc, strides, dil_compatible,
+        padding_l, padding_r, op_attr, aalgorithm, aprop_kind, aengine);
 
     dnnl::convolution_forward primitive(pd);
 
     conv_deconv_utils::obtain_runtime_zero_point(
-        src,
-        src_zero_point,
-        DNNL_ARG_SRC,
-        pd.get_primitive_attr(),
-        ideep::engine(pd.get_engine().get_kind()),
-        src_zp_tensor);
+      src, src_zero_point, DNNL_ARG_SRC, pd.get_primitive_attr(),
+      ideep::engine(pd.get_engine().get_kind()), src_zp_tensor);
 
-    param = {
-        std::move(pd),
-        std::move(primitive),
-        std::move(op_attr),
-        groups,
-        std::move(bias_attr)};
-    param.sq_param_ptr = std::make_shared<convolution_forward_quant_params>(
-        std::move(src_zp_tensor));
+    param = {std::move(pd), std::move(primitive), std::move(op_attr), groups, std::move(bias_attr)};
+    param.sq_param_ptr =
+        std::make_shared<convolution_forward_quant_params>(std::move(src_zp_tensor));
   }
 
   // do_compute with given primitive/pd, under the precondition
   // that whether or not src/weight/bias/dst need to be reorder
   // For both fp32 and int8
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void do_compute(
-      const convolution_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
+  static void do_compute(const convolution_forward_params& param,
+                         const tensor& src,
+                         const tensor& weights,
+                         const tensor& bias,
+                         tensor& dst) {
     auto scratchpad = tensor(param.pd.scratchpad_desc());
     static tensor empty_src_zero_point;
-    auto& src_zero_point = param.sq_param_ptr
-        ? param.sq_param_ptr->src_zero_point
-        : empty_src_zero_point;
+    auto& src_zero_point = param.sq_param_ptr ?
+        param.sq_param_ptr->src_zero_point : empty_src_zero_point;
 
-    auto& expected_src =
-        reorder_src ? src.reorder_if_differ_in(param.pd.src_desc()) : src;
+    auto& expected_src = reorder_src ?
+        src.reorder_if_differ_in(param.pd.src_desc()) : src;
     auto&& grouped_weights = weights.make_grouped_weights(param.groups);
-    auto&& expected_weights = reorder_weight
-        ? grouped_weights.reorder_if_differ_in(param.pd.weights_desc())
-        : grouped_weights;
-    if (reorder_src) {
-      dst.reinit_if_possible(param.pd.dst_desc());
-    }
+    auto&& expected_weights = reorder_weight ?
+        grouped_weights.reorder_if_differ_in(param.pd.weights_desc()) :
+        grouped_weights;
     auto& primitive = param.primitive;
     exec_args args;
     args.insert({DNNL_ARG_SRC, expected_src});
@@ -1933,9 +1360,9 @@ struct convolution_forward
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
     args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point});
     if (with_bias) {
-      auto& expected_bias = reorder_weight
-          ? bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr)
-          : bias;
+      auto& expected_bias = reorder_weight ?
+          bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr) :
+          bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
 
@@ -1964,79 +1391,77 @@ struct convolution_forward
 
   // For binary post-op
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void do_compute_binary(
-      const convolution_forward_params& param,
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
-    auto& pd = param.pd;
+  static void do_compute_binary(const convolution_forward_params &param,
+                                const tensor &src,
+                                const tensor &other,
+                                const tensor &weights,
+                                const tensor &bias,
+                                tensor &dst) {
+    auto &pd = param.pd;
     auto& primitive = param.primitive;
     auto scratchpad = tensor(pd.scratchpad_desc());
-    auto& expected_src =
-        reorder_src ? src.reorder_if_differ_in(pd.src_desc()) : src;
+    auto& expected_src = reorder_src ?
+        src.reorder_if_differ_in(pd.src_desc()) :
+        src;
     // make sure other has same format with dst.
     // TODO: other has different with dst?
-    auto& expected_other =
-        reorder_src ? other.reorder_if_differ_in(pd.dst_desc()) : other;
+    auto& expected_other = reorder_src ?
+        other.reorder_if_differ_in(pd.dst_desc()) :
+        other;
     auto&& grouped_weights = weights.make_grouped_weights(param.groups);
-    auto&& expected_weights = reorder_weight
-        ? grouped_weights.reorder_if_differ_in(pd.weights_desc())
-        : grouped_weights;
+    auto&& expected_weights = reorder_weight ?
+        grouped_weights.reorder_if_differ_in(pd.weights_desc()) :
+        grouped_weights;
     if (reorder_src) {
       dst.reinit_if_possible(pd.dst_desc());
     }
     if (with_bias) {
-      auto& expected_bias = reorder_weight
-          ? bias.reorder_if_differ_in(pd.bias_desc(), param.bias_attr)
-          : bias;
-      primitive.execute(
-          stream::default_stream(),
-          {{DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_WEIGHTS, expected_weights},
-           {DNNL_ARG_BIAS, expected_bias},
-           {DNNL_ARG_DST, dst},
-           {DNNL_ARG_SCRATCHPAD, scratchpad},
-           {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
-            expected_other}});
+      auto& expected_bias = reorder_weight ?
+          bias.reorder_if_differ_in(pd.bias_desc(), param.bias_attr) :
+          bias;
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_BIAS, expected_bias},
+                         {DNNL_ARG_DST, dst},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad},
+                         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
+                          expected_other}});
     } else {
-      primitive.execute(
-          stream::default_stream(),
-          {{DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_WEIGHTS, expected_weights},
-           {DNNL_ARG_DST, dst},
-           {DNNL_ARG_SCRATCHPAD, scratchpad},
-           {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
-            expected_other}});
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_DST, dst},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad},
+                         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
+                          expected_other}});
     }
   }
 };
 
+
 struct convolution_backward_data : public dnnl::convolution_backward_data {
+
   using super = dnnl::convolution_backward_data;
 
-  static void compute(
-      const tensor& diff_dst,
-      const tensor& weights,
-      const dims& diff_src_dims,
-      tensor& diff_src,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      const int groups,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::convolution_direct,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& diff_dst,
+                      const tensor& weights,
+                      const dims& diff_src_dims,
+                      tensor& diff_src,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      const int groups,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      const engine& aengine = engine::cpu_engine()) {
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups);
     auto dilates_ = utils::get_compatible_dilates(dilates);
 
     bool channels_last = diff_dst.get_desc().is_channels_last();
-    auto format_tag = channels_last
-        ? (diff_src_dims.size() == 4 ? tag::nhwc : tag::ndhwc)
-        : tag::any;
+    auto format_tag = channels_last ? (diff_src_dims.size() == 4 ? tag::nhwc : tag::ndhwc) : tag::any;
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
     // align weight data type with diff_dst for bf16
     auto weights_desc =
@@ -2050,28 +1475,12 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
 
     auto forward_hints =
         convolution_forward::get_primitive_desc</*with_bias=*/false>(
-            diff_src_desc,
-            weights_desc,
-            tensor::desc(),
-            diff_dst_desc,
-            strides,
-            dilates_,
-            padding_l,
-            padding_r,
-            op_attr);
+            diff_src_desc, weights_desc, tensor::desc(), diff_dst_desc, strides,
+            dilates_, padding_l, padding_r, op_attr);
 
     auto pd = primitive_desc(
-        {aalgorithm,
-         diff_src_desc,
-         weights_desc,
-         diff_dst_desc,
-         strides,
-         dilates_,
-         padding_l,
-         padding_r},
-        op_attr,
-        aengine,
-        forward_hints);
+        {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
+         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
@@ -2088,105 +1497,80 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(
-        stream::default_stream(),
-        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-         {DNNL_ARG_WEIGHTS, expected_weights},
-         {DNNL_ARG_DIFF_SRC, expected_diff_src},
-         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(stream::default_stream(), 
+                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+                       {DNNL_ARG_WEIGHTS, expected_weights},
+                       {DNNL_ARG_DIFF_SRC, expected_diff_src},
+                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
+
 struct convolution_backward_weights
     : public dnnl::convolution_backward_weights {
+
   using super = dnnl::convolution_backward_weights;
 
-  static void compute(
-      const tensor& src,
-      const tensor& diff_dst,
-      const dims& diff_weights_dims,
-      tensor& diff_weights,
-      tensor& diff_bias,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      const int groups,
-      const attr_t& attr = attr_t(),
-      const data_type diff_weight_type = data_type::undef,
-      algorithm aalgorithm = algorithm::convolution_direct,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& diff_dst,
+                      const dims& diff_weights_dims,
+                      tensor& diff_weights,
+                      tensor& diff_bias,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      const int groups,
+                      const attr_t& attr = attr_t(),
+                      const data_type diff_weight_type = data_type::undef,
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*with_diff_bias=*/true>(
-        src,
-        diff_dst,
-        diff_weights_dims,
-        diff_weights,
-        diff_bias,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        diff_weight_type,
-        aalgorithm,
-        aengine);
+        src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
+        strides, dilates, padding_l, padding_r, groups, attr, diff_weight_type, aalgorithm, aengine);
   }
 
-  static void compute(
-      const tensor& src,
-      const tensor& diff_dst,
-      const dims& diff_weights_dims,
-      tensor& diff_weights,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      const int groups,
-      const attr_t& attr = attr_t(),
-      const data_type diff_weight_type = data_type::undef,
-      algorithm aalgorithm = algorithm::convolution_direct,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& diff_dst,
+                      const dims& diff_weights_dims,
+                      tensor& diff_weights,
+                      const dims& strides,
+                      const dims& dilates,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      const int groups,
+                      const attr_t& attr = attr_t(),
+                      const data_type diff_weight_type = data_type::undef,
+                      algorithm aalgorithm = algorithm::convolution_direct,
+                      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
-        src,
-        diff_dst,
-        diff_weights_dims,
-        diff_weights,
-        dummy_diff_bias,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        diff_weight_type,
-        aalgorithm,
-        aengine);
+        src, diff_dst, diff_weights_dims, diff_weights, dummy_diff_bias,
+        strides, dilates, padding_l, padding_r, groups, attr, diff_weight_type, aalgorithm, aengine);
   }
 
  private:
   template <bool with_diff_bias>
-  static void compute_impl(
-      const tensor& src,
-      const tensor& diff_dst,
-      const dims& diff_weights_dims,
-      tensor& diff_weights,
-      tensor& diff_bias,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      const int groups,
-      const attr_t& attr,
-      const data_type diff_weight_type,
-      algorithm aalgorithm,
-      const engine& aengine) {
+  static void compute_impl(const tensor& src,
+                           const tensor& diff_dst,
+                           const dims& diff_weights_dims,
+                           tensor& diff_weights,
+                           tensor& diff_bias,
+                           const dims& strides,
+                           const dims& dilates,
+                           const dims& padding_l,
+                           const dims& padding_r,
+                           const int groups,
+                           const attr_t& attr,
+                           const data_type diff_weight_type,
+                           algorithm aalgorithm,
+                           const engine& aengine) {
+
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
     data_type diff_dst_type = diff_dst.get_data_type();
-    data_type diff_weight_type_in =
-        data_type::undef == diff_weight_type ? diff_dst_type : diff_weight_type;
+    data_type diff_weight_type_in = data_type::undef == diff_weight_type ?
+                                    diff_dst_type : diff_weight_type;
     auto diff_weights_desc =
         tensor::desc(diff_weights_dims, diff_weight_type_in, tag::any);
     if (groups > 1) {
@@ -2214,44 +1598,17 @@ struct convolution_backward_weights
 
     auto forward_hints =
         convolution_forward::get_primitive_desc<with_diff_bias>(
-            src_desc,
-            weights_desc,
-            diff_bias_desc,
-            diff_dst_desc,
-            strides,
-            dilates_,
-            padding_l,
-            padding_r,
-            op_attr,
-            aalgorithm,
-            prop_kind::forward,
-            aengine);
+            src_desc, weights_desc, diff_bias_desc, diff_dst_desc, strides,
+            dilates_, padding_l, padding_r,op_attr, aalgorithm,
+            prop_kind::forward, aengine);
 
-    auto pd = with_diff_bias ? primitive_desc(
-                                   {aalgorithm,
-                                    src_desc,
-                                    diff_weights_desc,
-                                    diff_bias_desc,
-                                    diff_dst_desc,
-                                    strides,
-                                    dilates_,
-                                    padding_l,
-                                    padding_r},
-                                   op_attr,
-                                   aengine,
-                                   forward_hints)
-                             : primitive_desc(
-                                   {aalgorithm,
-                                    src_desc,
-                                    diff_weights_desc,
-                                    diff_dst_desc,
-                                    strides,
-                                    dilates_,
-                                    padding_l,
-                                    padding_r},
-                                   op_attr,
-                                   aengine,
-                                   forward_hints);
+    auto pd = with_diff_bias
+        ? primitive_desc({aalgorithm, src_desc, diff_weights_desc,
+                          diff_bias_desc, diff_dst_desc, strides, dilates_,
+                          padding_l, padding_r}, op_attr, aengine, forward_hints)
+        : primitive_desc({aalgorithm, src_desc, diff_weights_desc,
+                          diff_dst_desc, strides, dilates_,
+                          padding_l, padding_r}, op_attr, aengine, forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
@@ -2272,20 +1629,18 @@ struct convolution_backward_weights
 
     if (with_diff_bias) {
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
-      super(pd).execute(
-          stream::default_stream(),
-          {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-           {DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-           {DNNL_ARG_DIFF_BIAS, diff_bias},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(stream::default_stream(),
+                        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+                        {DNNL_ARG_SRC, expected_src},
+                        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+                        {DNNL_ARG_DIFF_BIAS, diff_bias},
+                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      super(pd).execute(
-          stream::default_stream(),
-          {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-           {DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(stream::default_stream(),
+                        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+                        {DNNL_ARG_SRC, expected_src},
+                        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
     // diff_weights has been init in FW side, but has diff desc with
     // expected_diff_weights.
@@ -2294,6 +1649,6 @@ struct convolution_backward_weights
     }
   }
 };
-} // namespace ideep
+}  // namespace ideep
 
 #endif

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1502,6 +1502,11 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
                        {DNNL_ARG_WEIGHTS, expected_weights},
                        {DNNL_ARG_DIFF_SRC, expected_diff_src},
                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    // diff_src has been init in FW side, but has diff desc with
+    // expected_diff_src.
+    if (diff_src.get_desc() != expected_diff_src_desc) {
+      diff_src.feed_from(expected_diff_src);
+    }
   }
 };
 

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -441,7 +441,7 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       y_dims.push_back(1);
       y_dims.push_back(oc);
       auto valid_x_dim = [=](int idx) {
-        return std::max((padding_l[idx] + padding_r[idx] - (1 + (kernel_size[idx] - 1) * dilates[idx])) / strides[idx] + 2,
+          return std::max((padding_l[idx] + padding_r[idx] - (1 + (kernel_size[idx] - 1) * dilates[idx])) / strides[idx] + 2,
                           2 * kernel_size[idx]);
       };
       if (4 == src_size) {
@@ -486,7 +486,7 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     } else {
       // [o, i, ...] -> [i, o, ...]
       return tensor::desc(pd.weights_desc(), groups).transpose(0, 1);
-    }
+    } 
   }
 
   template <bool with_bias>
@@ -698,18 +698,18 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
           bias;
       primitive.execute(stream::default_stream(),
                         {{DNNL_ARG_SRC, expected_src},
-                        {DNNL_ARG_WEIGHTS, expected_weights},
-                        {DNNL_ARG_BIAS, expected_bias},
-                        {DNNL_ARG_DST, dst},
-                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
-                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_BIAS, expected_bias},
+                         {DNNL_ARG_DST, dst},
+                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
       primitive.execute(stream::default_stream(),
                         {{DNNL_ARG_SRC, expected_src},
-                        {DNNL_ARG_WEIGHTS, expected_weights},
-                        {DNNL_ARG_DST, dst},
-                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
-                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_DST, dst},
+                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
 
@@ -761,11 +761,11 @@ struct convolution_transpose_backward_data
     diff_src.reinit_if_possible(pd.diff_src_desc());
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(),
+    super(pd).execute(stream::default_stream(), 
                       {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                      {DNNL_ARG_WEIGHTS, expected_weights},
-                      {DNNL_ARG_DIFF_SRC, diff_src},
-                      {DNNL_ARG_SCRATCHPAD, scratchpad}});
+                       {DNNL_ARG_WEIGHTS, expected_weights},
+                       {DNNL_ARG_DIFF_SRC, diff_src},
+                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
@@ -787,9 +787,9 @@ struct convolution_transpose_backward_weights
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::deconvolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
-    compute_impl</*with_diff_bias=*/true>(
-        src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
-        strides, dilates, padding_l, padding_r, groups, attr, aalgorithm, aengine);
+   compute_impl</*with_diff_bias=*/true>(
+       src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
+       strides, dilates, padding_l, padding_r, groups, attr, aalgorithm, aengine);
   }
 
   static void compute(const tensor& src,
@@ -829,7 +829,7 @@ struct convolution_transpose_backward_weights
     auto dilates_ = utils::get_compatible_dilates(dilates);
 
     // dim: [i, o, ...]
-    auto diff_weights_desc =
+    auto diff_weights_desc = 
         tensor::desc(diff_weights_dims, diff_dst.get_data_type(), tag::any);
 
     if (groups > 1) {
@@ -888,16 +888,16 @@ struct convolution_transpose_backward_weights
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
       super(pd).execute(stream::default_stream(),
                         {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                        {DNNL_ARG_SRC, expected_src},
-                        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-                        {DNNL_ARG_DIFF_BIAS, diff_bias},
-                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+                         {DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+                         {DNNL_ARG_DIFF_BIAS, diff_bias},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
       super(pd).execute(stream::default_stream(),
                         {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                        {DNNL_ARG_SRC, expected_src},
-                        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+                         {DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
 
     diff_weights.feed_from(expected_diff_weights, /*is_deconv_weights=*/true);

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -39,8 +39,8 @@ struct deconv_forward_params {
 
   dnnl::deconvolution_forward::primitive_desc pd;
   dnnl::deconvolution_forward primitive;
-  attr_t bias_attr;
   int groups;
+  attr_t bias_attr;
   // Param for static quantization
   std::shared_ptr<deconv_forward_quant_params> sq_param_ptr;
 };

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -809,7 +809,7 @@ struct convolution_transpose_backward_weights
         src, diff_dst, diff_weights_dims, diff_weights, dummy_diff_bias,
         strides, dilates, padding_l, padding_r, groups, attr, aalgorithm, aengine);
   }
- private:
+private:
   template <bool with_diff_bias>
   static void compute_impl(const tensor& src,
                            const tensor& diff_dst,

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -46,7 +46,6 @@ struct deconv_forward_params {
 };
 
 struct convolution_transpose_forward : public dnnl::deconvolution_forward {
-
   using super = dnnl::deconvolution_forward;
 
   // 2-in-1 Compute for fp32
@@ -72,12 +71,36 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     } else {
       compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     }
   }
 
@@ -103,8 +126,20 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     static const tensor dummy_bias;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
   }
 
   // 2-in-1 Compute for int8
@@ -136,14 +171,48 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     } else {
       compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -175,9 +244,26 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     static const tensor dummy_bias;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // Prepare for fp32
@@ -200,12 +286,38 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare<false>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     } else {
       do_prepare<true>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          aengine);
     }
   }
 
@@ -228,8 +340,21 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     static const tensor dummy_bias;
     do_prepare<false>(
-        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
   }
 
   // Prepare for int8
@@ -258,14 +383,50 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare<false>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     } else {
       do_prepare<true>(
-          param, src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -294,9 +455,27 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     static const tensor dummy_bias;
     do_prepare<false>(
-        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   // Compute with prepared params. For both fp32 and int8
@@ -305,11 +484,12 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
   // src/dst and weight/bias should be checked and possibly reordered.
   // Set them to False if you are sure they don't need reordering.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const deconv_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst) {
+  static void compute(
+      const deconv_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     if (bias.is_empty()) {
       do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, weights, bias, dst);
@@ -325,10 +505,11 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
   // src/dst and weight/bias should be checked and possibly reordered.
   // Set them to False if you are sure they don't need reordering.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const deconv_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      tensor& dst) {
+  static void compute(
+      const deconv_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst) {
     static const tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -337,65 +518,119 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
   // Deprecated
   // With bias. Zero points are passed explicitly as arguments for quantization
   // Bias is not used if it is empty.
-  static void compute_v2(const tensor& src,
-                         const tensor& weights, // dim: {o, i[, d], h, w}
-                         const tensor& bias,
-                         const dims& dst_dims,
-                         tensor& dst,
-                         const dims& strides,
-                         const dims& padding_l,
-                         const dims& padding_r,
-                         const dims& dilates = {1, 1},
-                         int groups = 1,
-                         const scale_t& src_scales = scale_t(),
-                         const scale_t& weights_scales = scale_t(),
-                         const scale_t& dst_scales = scale_t(),
-                         const zero_point_t& src_zero_point = zero_point_t(),
-                         const zero_point_t& dst_zero_point = zero_point_t(),
-                         const attr_t& attr = attr_t(),
-                         algorithm aalgorithm = algorithm::deconvolution_direct,
-                         prop_kind aprop_kind = prop_kind::forward,
-                         const lowp_kind alowp_kind = u8s8,
-                         const engine& aengine = engine::cpu_engine()) {
+  static void compute_v2(
+      const tensor& src,
+      const tensor& weights, // dim: {o, i[, d], h, w}
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      int groups = 1,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const zero_point_t& src_zero_point = zero_point_t(),
+      const zero_point_t& dst_zero_point = zero_point_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, true, true>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     } else {
       compute_impl</*with_bias=*/true, true, true>(
-          src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst_dims,
+          dst,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          groups,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_point,
+          dst_zero_point,
+          attr,
+          aalgorithm,
+          aprop_kind,
+          alowp_kind,
+          aengine);
     }
   }
 
   // Deprecated
-  // Without bias. Zero points are passed explicitly as arguments for quantization
-  static void compute_v2(const tensor& src,
-                         const tensor& weights, // dim: {o, i[, d], h, w}
-                         const dims& dst_dims,
-                         tensor& dst,
-                         const dims& strides,
-                         const dims& padding_l,
-                         const dims& padding_r,
-                         const dims& dilates = {1, 1},
-                         int groups = 1,
-                         const scale_t& src_scales = scale_t(),
-                         const scale_t& weights_scales = scale_t(),
-                         const scale_t& dst_scales = scale_t(),
-                         const zero_point_t& src_zero_point = zero_point_t(),
-                         const zero_point_t& dst_zero_point = zero_point_t(),
-                         const attr_t& attr = attr_t(),
-                         algorithm aalgorithm = algorithm::deconvolution_direct,
-                         prop_kind aprop_kind = prop_kind::forward,
-                         const lowp_kind alowp_kind = u8s8,
-                         const engine& aengine = engine::cpu_engine()) {
+  // Without bias. Zero points are passed explicitly as arguments for
+  // quantization
+  static void compute_v2(
+      const tensor& src,
+      const tensor& weights, // dim: {o, i[, d], h, w}
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      int groups = 1,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const zero_point_t& src_zero_point = zero_point_t(),
+      const zero_point_t& dst_zero_point = zero_point_t(),
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      prop_kind aprop_kind = prop_kind::forward,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_impl</*with_bias=*/false, true, true>(
-        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
   }
 
   template <bool is_channels_last = false>
@@ -412,8 +647,8 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const dims& src_dims = dims(),
       const attr_t& attr = attr_t(),
       const engine& aengine = engine::cpu_engine()) {
-
-    auto src_size = weights_dims.size(); // weights_dims is 4 for conv2d and 5 for conv3d
+    auto src_size =
+        weights_dims.size(); // weights_dims is 4 for conv2d and 5 for conv3d
     auto grouped = groups > 1;
     auto weights_dims_g =
         grouped ? utils::group_dims(weights_dims, groups) : weights_dims;
@@ -441,8 +676,12 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       y_dims.push_back(1);
       y_dims.push_back(oc);
       auto valid_x_dim = [=](int idx) {
-          return std::max((padding_l[idx] + padding_r[idx] - (1 + (kernel_size[idx] - 1) * dilates[idx])) / strides[idx] + 2,
-                          2 * kernel_size[idx]);
+        return std::max(
+            (padding_l[idx] + padding_r[idx] -
+             (1 + (kernel_size[idx] - 1) * dilates[idx])) /
+                    strides[idx] +
+                2,
+            2 * kernel_size[idx]);
       };
       if (4 == src_size) {
         x_dims.push_back(valid_x_dim(0));
@@ -454,14 +693,16 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       }
     } else {
       // Use the real data
-      for (auto i=0; i < src_size; ++i) {
+      for (auto i = 0; i < src_size; ++i) {
         x_dims.push_back(src_dims[i]);
       }
       y_dims.push_back(src_dims[0]);
       y_dims.push_back(oc);
     }
     for (auto d = 2; d < src_size; ++d) {
-      auto out_size = (x_dims[d] - 1) * strides[d-2] + (1 + (kernel_size[d-2] - 1) * (dilates[d-2])) - padding_l[d-2] - padding_r[d-2];
+      auto out_size = (x_dims[d] - 1) * strides[d - 2] +
+          (1 + (kernel_size[d - 2] - 1) * (dilates[d - 2])) - padding_l[d - 2] -
+          padding_r[d - 2];
       y_dims.push_back(out_size);
     }
     auto x_dtype = (dtype != data_type::s8) ? dtype : data_type::u8;
@@ -476,8 +717,17 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     }
 
     auto pd = get_primitive_desc</*with_bias=*/false>(
-        src_desc, weights_desc, tensor::desc(), dst_desc, strides, dilates_,
-        padding_l, padding_r, attr, aalgorithm, aprop_kind);
+        src_desc,
+        weights_desc,
+        tensor::desc(),
+        dst_desc,
+        strides,
+        dilates_,
+        padding_l,
+        padding_r,
+        attr,
+        aalgorithm,
+        aprop_kind);
 
     // embed group info into weights_desc
     if (grouped) {
@@ -486,7 +736,7 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     } else {
       // [o, i, ...] -> [i, o, ...]
       return tensor::desc(pd.weights_desc(), groups).transpose(0, 1);
-    } 
+    }
   }
 
   template <bool with_bias>
@@ -512,72 +762,127 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     auto format_tag = is_nhwc ? tag::nhwc : (is_ndhwc ? tag::ndhwc : tag::any);
     auto src_desc_query = src_desc.to_format(format_tag);
     auto weights_desc_query = weights_desc.to_format_any();
-    auto bias_desc_query = with_bias ? bias_desc.to_format_any() : tensor::desc();
+    auto bias_desc_query =
+        with_bias ? bias_desc.to_format_any() : tensor::desc();
     auto dst_desc_query = dst_desc.to_format(format_tag);
 
     if (with_bias) {
-      return primitive_desc({aprop_kind, aalgorithm, src_desc_query,
-                             weights_desc_query, bias_desc_query, dst_desc_query,
-                             strides, dilates, padding_l, padding_r},
-                            attr, aengine);
+      return primitive_desc(
+          {aprop_kind,
+           aalgorithm,
+           src_desc_query,
+           weights_desc_query,
+           bias_desc_query,
+           dst_desc_query,
+           strides,
+           dilates,
+           padding_l,
+           padding_r},
+          attr,
+          aengine);
     } else {
-      return primitive_desc({aprop_kind, aalgorithm, src_desc_query,
-                             weights_desc_query, dst_desc_query,
-                             strides, dilates, padding_l, padding_r},
-                            attr, aengine);
+      return primitive_desc(
+          {aprop_kind,
+           aalgorithm,
+           src_desc_query,
+           weights_desc_query,
+           dst_desc_query,
+           strides,
+           dilates,
+           padding_l,
+           padding_r},
+          attr,
+          aengine);
     }
   }
 
  private:
   // For 2-in-1 compute. For fp32
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void compute_impl(const tensor& src,
-                           const tensor& weights,
-                           const tensor& bias,
-                           const dims& dst_dims,
-                           tensor& dst,
-                           const dims& strides,
-                           const dims& dilates,
-                           const dims& padding_l,
-                           const dims& padding_r,
-                           int groups,
-                           const attr_t& attr,
-                           algorithm aalgorithm,
-                           prop_kind aprop_kind,
-                           const engine& aengine) {
+  static void compute_impl(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const attr_t& attr,
+      algorithm aalgorithm,
+      prop_kind aprop_kind,
+      const engine& aengine) {
     deconv_forward_params param;
-    do_prepare<with_bias>(param, src, weights, bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
-    do_compute<with_bias, reorder_src, reorder_weight>(param, src, weights, bias, dst);
+    do_prepare<with_bias>(
+        param,
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
+    do_compute<with_bias, reorder_src, reorder_weight>(
+        param, src, weights, bias, dst);
   }
 
   // For 2-in-1 compute. For int8
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void compute_impl(const tensor& src,
-                           const tensor& weights,
-                           const tensor& bias,
-                           const dims& dst_dims,
-                           tensor& dst,
-                           const dims& strides,
-                           const dims& dilates,
-                           const dims& padding_l,
-                           const dims& padding_r,
-                           int groups,
-                           const scale_t& src_scales,
-                           const scale_t& weights_scales,
-                           const scale_t& dst_scales,
-                           const zero_point_t& src_zero_point,
-                           const zero_point_t& dst_zero_point,
-                           const attr_t& attr,
-                           algorithm aalgorithm,
-                           prop_kind aprop_kind,
-                           const lowp_kind alowp_kind,
-                           const engine& aengine) {
+  static void compute_impl(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_point,
+      const zero_point_t& dst_zero_point,
+      const attr_t& attr,
+      algorithm aalgorithm,
+      prop_kind aprop_kind,
+      const lowp_kind alowp_kind,
+      const engine& aengine) {
     deconv_forward_params param;
-    do_prepare<with_bias>(param, src, weights, bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
-    do_compute<with_bias, reorder_src, reorder_weight>(param, src, weights, bias, dst);
+    do_prepare<with_bias>(
+        param,
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        aalgorithm,
+        aprop_kind,
+        alowp_kind,
+        aengine);
+    do_compute<with_bias, reorder_src, reorder_weight>(
+        param, src, weights, bias, dst);
   }
 
   // For fp32
@@ -604,15 +909,40 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src, weights, bias, dst_dims, dst, dilates, groups,
-        attr, with_bias, /*is_deconv=*/true, weights_grouped,
-        dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
-        src_desc, weights_desc, bias_desc, dst_desc);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        dilates,
+        groups,
+        attr,
+        with_bias,
+        /*is_deconv=*/true,
+        weights_grouped,
+        dil_compatible,
+        op_attr,
+        src_attr,
+        weights_attr,
+        bias_attr,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc);
 
     param.pd = get_primitive_desc<with_bias>(
-                  src_desc, weights_desc, bias_desc, dst_desc,
-                  strides, dil_compatible, padding_l, padding_r, op_attr, aalgorithm,
-                  aprop_kind, aengine);
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        strides,
+        dil_compatible,
+        padding_l,
+        padding_r,
+        op_attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
 
     param.primitive = std::move(super(param.pd));
     param.bias_attr = std::move(bias_attr);
@@ -621,118 +951,156 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
 
   // For int8
   template <bool with_bias>
-  static void do_prepare(deconv_forward_params& param,
-                         const tensor& src,
-                         const tensor& weights,
-                         const tensor& bias,
-                         const dims& dst_dims,
-                         tensor& dst,
-                         const dims& strides,
-                         const dims& dilates,
-                         const dims& padding_l,
-                         const dims& padding_r,
-                         int groups,
-                         const scale_t& src_scales,
-                         const scale_t& weights_scales,
-                         const scale_t& dst_scales,
-                         const zero_point_t& src_zero_point,
-                         const zero_point_t& dst_zero_point,
-                         const attr_t& attr,
-                         algorithm aalgorithm,
-                         prop_kind aprop_kind,
-                         const lowp_kind alowp_kind,
-                         const engine& aengine) {
+  static void do_prepare(
+      deconv_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      const dims& dst_dims,
+      tensor& dst,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      int groups,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_point,
+      const zero_point_t& dst_zero_point,
+      const attr_t& attr,
+      algorithm aalgorithm,
+      prop_kind aprop_kind,
+      const lowp_kind alowp_kind,
+      const engine& aengine) {
     tensor::desc src_desc, weights_desc, bias_desc, dst_desc;
     attr_t op_attr, src_attr, weights_attr, bias_attr;
     tensor weights_grouped;
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src, weights, bias, dst_dims, dst, dilates, groups,
-        src_scales, weights_scales, dst_scales, src_zero_point, dst_zero_point,
-        attr, alowp_kind, with_bias, /*is_deconv=*/true,
-        weights_grouped, dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
-        src_desc, weights_desc, bias_desc, dst_desc);
+        src,
+        weights,
+        bias,
+        dst_dims,
+        dst,
+        dilates,
+        groups,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_point,
+        dst_zero_point,
+        attr,
+        alowp_kind,
+        with_bias,
+        /*is_deconv=*/true,
+        weights_grouped,
+        dil_compatible,
+        op_attr,
+        src_attr,
+        weights_attr,
+        bias_attr,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc);
 
     param.pd = get_primitive_desc<with_bias>(
-                  src_desc, weights_desc, bias_desc, dst_desc,
-                  strides, dil_compatible, padding_l, padding_r, op_attr, aalgorithm,
-                  aprop_kind, aengine);
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        strides,
+        dil_compatible,
+        padding_l,
+        padding_r,
+        op_attr,
+        aalgorithm,
+        aprop_kind,
+        aengine);
 
     tensor src_zero_point_m;
-    conv_deconv_utils::obtain_runtime_zero_point(src, src_zero_point, DNNL_ARG_SRC,
-                                                 op_attr, aengine, src_zero_point_m);
+    conv_deconv_utils::obtain_runtime_zero_point(
+        src, src_zero_point, DNNL_ARG_SRC, op_attr, aengine, src_zero_point_m);
     param.primitive = std::move(super(param.pd));
     param.bias_attr = std::move(bias_attr);
     param.groups = groups;
-    param.sq_param_ptr =
-        std::make_shared<deconv_forward_quant_params>(std::move(src_zero_point_m));
-    IDEEP_ENFORCE(param.sq_param_ptr, "Failed to allocate memory for quantization parameters");
+    param.sq_param_ptr = std::make_shared<deconv_forward_quant_params>(
+        std::move(src_zero_point_m));
+    IDEEP_ENFORCE(
+        param.sq_param_ptr,
+        "Failed to allocate memory for quantization parameters");
   }
 
   // For fp32 and int8
   // `reorder_src` and `reorder_weight` indicate whether
   // src/dst and weight/bias should be checked and possibly reordered
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void do_compute(const deconv_forward_params& param,
-                         const tensor& src,
-                         const tensor& weights,
-                         const tensor& bias,
-                         tensor& dst) {
+  static void do_compute(
+      const deconv_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     auto scratchpad = tensor(param.pd.scratchpad_desc());
     static tensor empty_src_zero_point;
-    auto& src_zero_point = param.sq_param_ptr ?
-        param.sq_param_ptr->src_zero_point : empty_src_zero_point;
-    auto& expected_src = reorder_src ?
-        src.reorder_if_differ_in(param.pd.src_desc()) : src;
-    auto&& grouped_weights = weights.make_grouped_weights(param.groups, /*is_deconv=*/true);
-    auto&& expected_weights = reorder_weight ?
-        grouped_weights.reorder_if_differ_in(param.pd.weights_desc()) :
-        grouped_weights;
+    auto& src_zero_point = param.sq_param_ptr
+        ? param.sq_param_ptr->src_zero_point
+        : empty_src_zero_point;
+    auto& expected_src =
+        reorder_src ? src.reorder_if_differ_in(param.pd.src_desc()) : src;
+    auto&& grouped_weights =
+        weights.make_grouped_weights(param.groups, /*is_deconv=*/true);
+    auto&& expected_weights = reorder_weight
+        ? grouped_weights.reorder_if_differ_in(param.pd.weights_desc())
+        : grouped_weights;
     if (reorder_src) {
       dst.reinit_if_possible(param.pd.dst_desc());
     }
     auto& primitive = param.primitive;
 
     if (with_bias) {
-      auto& expected_bias = reorder_weight ?
-          bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr) :
-          bias;
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_BIAS, expected_bias},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      auto& expected_bias = reorder_weight
+          ? bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr)
+          : bias;
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_BIAS, expected_bias},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, dst},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
-
 };
 
 struct convolution_transpose_backward_data
     : public dnnl::deconvolution_backward_data {
-
   using super = dnnl::deconvolution_backward_data;
 
-  static void compute(const tensor& diff_dst,
-                      const tensor& weights, // dim: {i, o[, d], h, w}
-                      const dims& diff_src_dims,
-                      tensor& diff_src,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      const int groups = 1,
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& diff_dst,
+      const tensor& weights, // dim: {i, o[, d], h, w}
+      const dims& diff_src_dims,
+      tensor& diff_src,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      const int groups = 1,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups, true);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -743,91 +1111,136 @@ struct convolution_transpose_backward_data
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
     auto weights_desc = weights_.get_desc().to_format_any();
 
-    tensor::desc diff_src_desc(diff_src_dims, diff_dst_desc.get_data_type(), format_tag);
+    tensor::desc diff_src_desc(
+        diff_src_dims, diff_dst_desc.get_data_type(), format_tag);
+
+    auto op_attr = attr;
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto forward_hints =
         convolution_transpose_forward::get_primitive_desc</*with_bias=*/false>(
-            diff_src_desc, weights_desc, tensor::desc(), diff_dst_desc, strides,
-            dilates_, padding_l, padding_r);
-
-    auto op_attr = dnnl::primitive_attr();
-    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+            diff_src_desc,
+            weights_desc,
+            tensor::desc(),
+            diff_dst_desc,
+            strides,
+            dilates_,
+            padding_l,
+            padding_r,
+            op_attr);
 
     auto pd = primitive_desc(
-        {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
-         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
+        {aalgorithm,
+         diff_src_desc,
+         weights_desc,
+         diff_dst_desc,
+         strides,
+         dilates_,
+         padding_l,
+         padding_r},
+        op_attr,
+        aengine,
+        forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(), 
-                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                       {DNNL_ARG_WEIGHTS, expected_weights},
-                       {DNNL_ARG_DIFF_SRC, diff_src},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+         {DNNL_ARG_WEIGHTS, expected_weights},
+         {DNNL_ARG_DIFF_SRC, diff_src},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
 struct convolution_transpose_backward_weights
     : public dnnl::deconvolution_backward_weights {
-
   using super = dnnl::deconvolution_backward_weights;
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      const dims& diff_weights_dims,
-                      tensor& diff_weights,
-                      tensor& diff_bias,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      const int groups = 1,
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
-   compute_impl</*with_diff_bias=*/true>(
-       src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
-       strides, dilates, padding_l, padding_r, groups, aalgorithm, aengine);
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims,
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      const int groups = 1,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
+    compute_impl</*with_diff_bias=*/true>(
+        src,
+        diff_dst,
+        diff_weights_dims,
+        diff_weights,
+        diff_bias,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aengine);
   }
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      const dims& diff_weights_dims,
-                      tensor& diff_weights,
-                      const dims& strides,
-                      const dims& padding_l,
-                      const dims& padding_r,
-                      const dims& dilates = {1, 1},
-                      const int groups = 1,
-                      algorithm aalgorithm = algorithm::deconvolution_direct,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims,
+      tensor& diff_weights,
+      const dims& strides,
+      const dims& padding_l,
+      const dims& padding_r,
+      const dims& dilates = {1, 1},
+      const int groups = 1,
+      const attr_t& attr = attr_t(),
+      algorithm aalgorithm = algorithm::deconvolution_direct,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
-        src, diff_dst, diff_weights_dims, diff_weights, dummy_diff_bias,
-        strides, dilates, padding_l, padding_r, groups, aalgorithm, aengine);
+        src,
+        diff_dst,
+        diff_weights_dims,
+        diff_weights,
+        dummy_diff_bias,
+        strides,
+        dilates,
+        padding_l,
+        padding_r,
+        groups,
+        attr,
+        aalgorithm,
+        aengine);
   }
-private:
-  template <bool with_diff_bias>
-  static void compute_impl(const tensor& src,
-                           const tensor& diff_dst,
-                           const dims& diff_weights_dims, // [i, o, ...]
-                           tensor& diff_weights,
-                           tensor& diff_bias,
-                           const dims& strides,
-                           const dims& dilates,
-                           const dims& padding_l,
-                           const dims& padding_r,
-                           const int groups,
-                           algorithm aalgorithm,
-                           const engine& aengine) {
 
+ private:
+  template <bool with_diff_bias>
+  static void compute_impl(
+      const tensor& src,
+      const tensor& diff_dst,
+      const dims& diff_weights_dims, // [i, o, ...]
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const dims& strides,
+      const dims& dilates,
+      const dims& padding_l,
+      const dims& padding_r,
+      const int groups,
+      const attr_t& attr,
+      algorithm aalgorithm,
+      const engine& aengine) {
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
 
     // dim: [i, o, ...]
-    auto diff_weights_desc = 
+    auto diff_weights_desc =
         tensor::desc(diff_weights_dims, diff_dst.get_data_type(), tag::any);
 
     if (groups > 1) {
@@ -849,22 +1262,49 @@ private:
               .to_format_any()
         : tensor::desc();
 
-    auto forward_hints =
-        convolution_transpose_forward::get_primitive_desc<with_diff_bias>(
-            src_desc, diff_weights_desc, diff_bias_desc, diff_dst_desc, strides,
-            dilates_, padding_l, padding_r, attr_t(), aalgorithm,
-            prop_kind::forward, aengine);
-
-    auto op_attr = dnnl::primitive_attr();
+    auto op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    auto pd = with_diff_bias
-        ? primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_bias_desc, diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints)
-        : primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints);
+    auto forward_hints =
+        convolution_transpose_forward::get_primitive_desc<with_diff_bias>(
+            src_desc,
+            diff_weights_desc,
+            diff_bias_desc,
+            diff_dst_desc,
+            strides,
+            dilates_,
+            padding_l,
+            padding_r,
+            op_attr,
+            aalgorithm,
+            prop_kind::forward,
+            aengine);
+
+    auto pd = with_diff_bias ? primitive_desc(
+                                   {aalgorithm,
+                                    src_desc,
+                                    diff_weights_desc,
+                                    diff_bias_desc,
+                                    diff_dst_desc,
+                                    strides,
+                                    dilates_,
+                                    padding_l,
+                                    padding_r},
+                                   op_attr,
+                                   aengine,
+                                   forward_hints)
+                             : primitive_desc(
+                                   {aalgorithm,
+                                    src_desc,
+                                    diff_weights_desc,
+                                    diff_dst_desc,
+                                    strides,
+                                    dilates_,
+                                    padding_l,
+                                    padding_r},
+                                   op_attr,
+                                   aengine,
+                                   forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
@@ -912,6 +1352,6 @@ private:
     }
   }
 };
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -46,6 +46,7 @@ struct deconv_forward_params {
 };
 
 struct convolution_transpose_forward : public dnnl::deconvolution_forward {
+
   using super = dnnl::deconvolution_forward;
 
   // 2-in-1 Compute for fp32
@@ -71,36 +72,12 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     } else {
       compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     }
   }
 
@@ -126,20 +103,8 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     static const tensor dummy_bias;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
   }
 
   // 2-in-1 Compute for int8
@@ -171,48 +136,14 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     } else {
       compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 
@@ -244,26 +175,9 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     static const tensor dummy_bias;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        alowp_kind,
-        aengine);
+        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
   // Prepare for fp32
@@ -286,38 +200,12 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare<false>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     } else {
       do_prepare<true>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     }
   }
 
@@ -340,21 +228,8 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     static const tensor dummy_bias;
     do_prepare<false>(
-        param,
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
   }
 
   // Prepare for int8
@@ -383,50 +258,14 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_prepare<false>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     } else {
       do_prepare<true>(
-          param,
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          param, src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 
@@ -455,27 +294,9 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const engine& aengine = engine::cpu_engine()) {
     static const tensor dummy_bias;
     do_prepare<false>(
-        param,
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        alowp_kind,
-        aengine);
+        param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
   // Compute with prepared params. For both fp32 and int8
@@ -484,12 +305,11 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
   // src/dst and weight/bias should be checked and possibly reordered.
   // Set them to False if you are sure they don't need reordering.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const deconv_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
+  static void compute(const deconv_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst) {
     if (bias.is_empty()) {
       do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, weights, bias, dst);
@@ -505,11 +325,10 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
   // src/dst and weight/bias should be checked and possibly reordered.
   // Set them to False if you are sure they don't need reordering.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const deconv_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      tensor& dst) {
+  static void compute(const deconv_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      tensor& dst) {
     static const tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -518,124 +337,70 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
   // Deprecated
   // With bias. Zero points are passed explicitly as arguments for quantization
   // Bias is not used if it is empty.
-  static void compute_v2(
-      const tensor& src,
-      const tensor& weights, // dim: {o, i[, d], h, w}
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& padding_l,
-      const dims& padding_r,
-      const dims& dilates = {1, 1},
-      int groups = 1,
-      const scale_t& src_scales = scale_t(),
-      const scale_t& weights_scales = scale_t(),
-      const scale_t& dst_scales = scale_t(),
-      const zero_point_t& src_zero_point = zero_point_t(),
-      const zero_point_t& dst_zero_point = zero_point_t(),
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::deconvolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute_v2(const tensor& src,
+                         const tensor& weights, // dim: {o, i[, d], h, w}
+                         const tensor& bias,
+                         const dims& dst_dims,
+                         tensor& dst,
+                         const dims& strides,
+                         const dims& padding_l,
+                         const dims& padding_r,
+                         const dims& dilates = {1, 1},
+                         int groups = 1,
+                         const scale_t& src_scales = scale_t(),
+                         const scale_t& weights_scales = scale_t(),
+                         const scale_t& dst_scales = scale_t(),
+                         const zero_point_t& src_zero_point = zero_point_t(),
+                         const zero_point_t& dst_zero_point = zero_point_t(),
+                         const attr_t& attr = attr_t(),
+                         algorithm aalgorithm = algorithm::deconvolution_direct,
+                         prop_kind aprop_kind = prop_kind::forward,
+                         const lowp_kind alowp_kind = u8s8,
+                         const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, true, true>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     } else {
       compute_impl</*with_bias=*/true, true, true>(
-          src,
-          weights,
-          bias,
-          dst_dims,
-          dst,
-          strides,
-          dilates,
-          padding_l,
-          padding_r,
-          groups,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_point,
-          dst_zero_point,
-          attr,
-          aalgorithm,
-          aprop_kind,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst_dims, dst, strides, dilates,
+          padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+          src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 
   // Deprecated
-  // Without bias. Zero points are passed explicitly as arguments for
-  // quantization
-  static void compute_v2(
-      const tensor& src,
-      const tensor& weights, // dim: {o, i[, d], h, w}
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& padding_l,
-      const dims& padding_r,
-      const dims& dilates = {1, 1},
-      int groups = 1,
-      const scale_t& src_scales = scale_t(),
-      const scale_t& weights_scales = scale_t(),
-      const scale_t& dst_scales = scale_t(),
-      const zero_point_t& src_zero_point = zero_point_t(),
-      const zero_point_t& dst_zero_point = zero_point_t(),
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::deconvolution_direct,
-      prop_kind aprop_kind = prop_kind::forward,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  // Without bias. Zero points are passed explicitly as arguments for quantization
+  static void compute_v2(const tensor& src,
+                         const tensor& weights, // dim: {o, i[, d], h, w}
+                         const dims& dst_dims,
+                         tensor& dst,
+                         const dims& strides,
+                         const dims& padding_l,
+                         const dims& padding_r,
+                         const dims& dilates = {1, 1},
+                         int groups = 1,
+                         const scale_t& src_scales = scale_t(),
+                         const scale_t& weights_scales = scale_t(),
+                         const scale_t& dst_scales = scale_t(),
+                         const zero_point_t& src_zero_point = zero_point_t(),
+                         const zero_point_t& dst_zero_point = zero_point_t(),
+                         const attr_t& attr = attr_t(),
+                         algorithm aalgorithm = algorithm::deconvolution_direct,
+                         prop_kind aprop_kind = prop_kind::forward,
+                         const lowp_kind alowp_kind = u8s8,
+                         const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_impl</*with_bias=*/false, true, true>(
-        src,
-        weights,
-        dummy_bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        alowp_kind,
-        aengine);
+        src, weights, dummy_bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
   }
 
   template <bool is_channels_last = false>
   static tensor::desc expected_weights_desc(
-      const dims& weights_dims, // [i, o, ...]
+      const dims& weights_dims,   // [i, o, ...]
       data_type dtype = data_type::f32,
       const dims& strides = {1, 1},
       const dims& padding_l = {0, 0},
@@ -647,8 +412,8 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       const dims& src_dims = dims(),
       const attr_t& attr = attr_t(),
       const engine& aengine = engine::cpu_engine()) {
-    auto src_size =
-        weights_dims.size(); // weights_dims is 4 for conv2d and 5 for conv3d
+
+    auto src_size = weights_dims.size(); // weights_dims is 4 for conv2d and 5 for conv3d
     auto grouped = groups > 1;
     auto weights_dims_g =
         grouped ? utils::group_dims(weights_dims, groups) : weights_dims;
@@ -676,12 +441,8 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       y_dims.push_back(1);
       y_dims.push_back(oc);
       auto valid_x_dim = [=](int idx) {
-        return std::max(
-            (padding_l[idx] + padding_r[idx] -
-             (1 + (kernel_size[idx] - 1) * dilates[idx])) /
-                    strides[idx] +
-                2,
-            2 * kernel_size[idx]);
+        return std::max((padding_l[idx] + padding_r[idx] - (1 + (kernel_size[idx] - 1) * dilates[idx])) / strides[idx] + 2,
+                          2 * kernel_size[idx]);
       };
       if (4 == src_size) {
         x_dims.push_back(valid_x_dim(0));
@@ -693,16 +454,14 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
       }
     } else {
       // Use the real data
-      for (auto i = 0; i < src_size; ++i) {
+      for (auto i=0; i < src_size; ++i) {
         x_dims.push_back(src_dims[i]);
       }
       y_dims.push_back(src_dims[0]);
       y_dims.push_back(oc);
     }
     for (auto d = 2; d < src_size; ++d) {
-      auto out_size = (x_dims[d] - 1) * strides[d - 2] +
-          (1 + (kernel_size[d - 2] - 1) * (dilates[d - 2])) - padding_l[d - 2] -
-          padding_r[d - 2];
+      auto out_size = (x_dims[d] - 1) * strides[d-2] + (1 + (kernel_size[d-2] - 1) * (dilates[d-2])) - padding_l[d-2] - padding_r[d-2];
       y_dims.push_back(out_size);
     }
     auto x_dtype = (dtype != data_type::s8) ? dtype : data_type::u8;
@@ -717,17 +476,8 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     }
 
     auto pd = get_primitive_desc</*with_bias=*/false>(
-        src_desc,
-        weights_desc,
-        tensor::desc(),
-        dst_desc,
-        strides,
-        dilates_,
-        padding_l,
-        padding_r,
-        attr,
-        aalgorithm,
-        aprop_kind);
+        src_desc, weights_desc, tensor::desc(), dst_desc, strides, dilates_,
+        padding_l, padding_r, attr, aalgorithm, aprop_kind);
 
     // embed group info into weights_desc
     if (grouped) {
@@ -757,132 +507,75 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     // while activation uses format_tag::nhwc
     bool is_nhwc = src_desc.is_nhwc() || weights_desc.is_nhwc();
     bool is_ndhwc = src_desc.is_ndhwc() || weights_desc.is_ndhwc();
-    // bool is_nhwc = src_desc.is_nhwc();
-    // bool is_ndhwc = src_desc.is_ndhwc();
     auto format_tag = is_nhwc ? tag::nhwc : (is_ndhwc ? tag::ndhwc : tag::any);
     auto src_desc_query = src_desc.to_format(format_tag);
     auto weights_desc_query = weights_desc.to_format_any();
-    auto bias_desc_query =
-        with_bias ? bias_desc.to_format_any() : tensor::desc();
+    auto bias_desc_query = with_bias ? bias_desc.to_format_any() : tensor::desc();
     auto dst_desc_query = dst_desc.to_format(format_tag);
 
     if (with_bias) {
-      return primitive_desc(
-          {aprop_kind,
-           aalgorithm,
-           src_desc_query,
-           weights_desc_query,
-           bias_desc_query,
-           dst_desc_query,
-           strides,
-           dilates,
-           padding_l,
-           padding_r},
-          attr,
-          aengine);
+      return primitive_desc({aprop_kind, aalgorithm, src_desc_query,
+                             weights_desc_query, bias_desc_query, dst_desc_query,
+                             strides, dilates, padding_l, padding_r},
+                            attr, aengine);
     } else {
-      return primitive_desc(
-          {aprop_kind,
-           aalgorithm,
-           src_desc_query,
-           weights_desc_query,
-           dst_desc_query,
-           strides,
-           dilates,
-           padding_l,
-           padding_r},
-          attr,
-          aengine);
+      return primitive_desc({aprop_kind, aalgorithm, src_desc_query,
+                             weights_desc_query, dst_desc_query,
+                             strides, dilates, padding_l, padding_r},
+                            attr, aengine);
     }
   }
 
  private:
   // For 2-in-1 compute. For fp32
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void compute_impl(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const attr_t& attr,
-      algorithm aalgorithm,
-      prop_kind aprop_kind,
-      const engine& aengine) {
+  static void compute_impl(const tensor& src,
+                           const tensor& weights,
+                           const tensor& bias,
+                           const dims& dst_dims,
+                           tensor& dst,
+                           const dims& strides,
+                           const dims& dilates,
+                           const dims& padding_l,
+                           const dims& padding_r,
+                           int groups,
+                           const attr_t& attr,
+                           algorithm aalgorithm,
+                           prop_kind aprop_kind,
+                           const engine& aengine) {
     deconv_forward_params param;
-    do_prepare<with_bias>(
-        param,
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
-    do_compute<with_bias, reorder_src, reorder_weight>(
-        param, src, weights, bias, dst);
+    do_prepare<with_bias>(param, src, weights, bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
+    do_compute<with_bias, reorder_src, reorder_weight>(param, src, weights, bias, dst);
   }
 
   // For 2-in-1 compute. For int8
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void compute_impl(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales,
-      const scale_t& weights_scales,
-      const scale_t& dst_scales,
-      const zero_point_t& src_zero_point,
-      const zero_point_t& dst_zero_point,
-      const attr_t& attr,
-      algorithm aalgorithm,
-      prop_kind aprop_kind,
-      const lowp_kind alowp_kind,
-      const engine& aengine) {
+  static void compute_impl(const tensor& src,
+                           const tensor& weights,
+                           const tensor& bias,
+                           const dims& dst_dims,
+                           tensor& dst,
+                           const dims& strides,
+                           const dims& dilates,
+                           const dims& padding_l,
+                           const dims& padding_r,
+                           int groups,
+                           const scale_t& src_scales,
+                           const scale_t& weights_scales,
+                           const scale_t& dst_scales,
+                           const zero_point_t& src_zero_point,
+                           const zero_point_t& dst_zero_point,
+                           const attr_t& attr,
+                           algorithm aalgorithm,
+                           prop_kind aprop_kind,
+                           const lowp_kind alowp_kind,
+                           const engine& aengine) {
     deconv_forward_params param;
-    do_prepare<with_bias>(
-        param,
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        aalgorithm,
-        aprop_kind,
-        alowp_kind,
-        aengine);
-    do_compute<with_bias, reorder_src, reorder_weight>(
-        param, src, weights, bias, dst);
+    do_prepare<with_bias>(param, src, weights, bias, dst_dims, dst, strides, dilates,
+        padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
+        src_zero_point, dst_zero_point, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+    do_compute<with_bias, reorder_src, reorder_weight>(param, src, weights, bias, dst);
   }
 
   // For fp32
@@ -909,40 +602,15 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        dilates,
-        groups,
-        attr,
-        with_bias,
-        /*is_deconv=*/true,
-        weights_grouped,
-        dil_compatible,
-        op_attr,
-        src_attr,
-        weights_attr,
-        bias_attr,
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc);
+        src, weights, bias, dst_dims, dst, dilates, groups,
+        attr, with_bias, /*is_deconv=*/true, weights_grouped,
+        dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
+        src_desc, weights_desc, bias_desc, dst_desc);
 
     param.pd = get_primitive_desc<with_bias>(
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        strides,
-        dil_compatible,
-        padding_l,
-        padding_r,
-        op_attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+                  src_desc, weights_desc, bias_desc, dst_desc,
+                  strides, dil_compatible, padding_l, padding_r, op_attr, aalgorithm,
+                  aprop_kind, aengine);
 
     param.primitive = std::move(super(param.pd));
     param.bias_attr = std::move(bias_attr);
@@ -951,156 +619,119 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
 
   // For int8
   template <bool with_bias>
-  static void do_prepare(
-      deconv_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      const dims& dst_dims,
-      tensor& dst,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      int groups,
-      const scale_t& src_scales,
-      const scale_t& weights_scales,
-      const scale_t& dst_scales,
-      const zero_point_t& src_zero_point,
-      const zero_point_t& dst_zero_point,
-      const attr_t& attr,
-      algorithm aalgorithm,
-      prop_kind aprop_kind,
-      const lowp_kind alowp_kind,
-      const engine& aengine) {
+  static void do_prepare(deconv_forward_params& param,
+                         const tensor& src,
+                         const tensor& weights,
+                         const tensor& bias,
+                         const dims& dst_dims,
+                         tensor& dst,
+                         const dims& strides,
+                         const dims& dilates,
+                         const dims& padding_l,
+                         const dims& padding_r,
+                         int groups,
+                         const scale_t& src_scales,
+                         const scale_t& weights_scales,
+                         const scale_t& dst_scales,
+                         const zero_point_t& src_zero_point,
+                         const zero_point_t& dst_zero_point,
+                         const attr_t& attr,
+                         algorithm aalgorithm,
+                         prop_kind aprop_kind,
+                         const lowp_kind alowp_kind,
+                         const engine& aengine) {
     tensor::desc src_desc, weights_desc, bias_desc, dst_desc;
     attr_t op_attr, src_attr, weights_attr, bias_attr;
     tensor weights_grouped;
     dims dil_compatible;
 
     conv_deconv_utils::prepare_parameters(
-        src,
-        weights,
-        bias,
-        dst_dims,
-        dst,
-        dilates,
-        groups,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_point,
-        dst_zero_point,
-        attr,
-        alowp_kind,
-        with_bias,
-        /*is_deconv=*/true,
-        weights_grouped,
-        dil_compatible,
-        op_attr,
-        src_attr,
-        weights_attr,
-        bias_attr,
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc);
+        src, weights, bias, dst_dims, dst, dilates, groups,
+        src_scales, weights_scales, dst_scales, src_zero_point, dst_zero_point,
+        attr, alowp_kind, with_bias, /*is_deconv=*/true,
+        weights_grouped, dil_compatible, op_attr, src_attr, weights_attr, bias_attr,
+        src_desc, weights_desc, bias_desc, dst_desc);
 
     param.pd = get_primitive_desc<with_bias>(
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        strides,
-        dil_compatible,
-        padding_l,
-        padding_r,
-        op_attr,
-        aalgorithm,
-        aprop_kind,
-        aengine);
+                  src_desc, weights_desc, bias_desc, dst_desc,
+                  strides, dil_compatible, padding_l, padding_r, op_attr, aalgorithm,
+                  aprop_kind, aengine);
 
     tensor src_zero_point_m;
-    conv_deconv_utils::obtain_runtime_zero_point(
-        src, src_zero_point, DNNL_ARG_SRC, op_attr, aengine, src_zero_point_m);
+    conv_deconv_utils::obtain_runtime_zero_point(src, src_zero_point, DNNL_ARG_SRC,
+                                                 op_attr, aengine, src_zero_point_m);
     param.primitive = std::move(super(param.pd));
     param.bias_attr = std::move(bias_attr);
     param.groups = groups;
-    param.sq_param_ptr = std::make_shared<deconv_forward_quant_params>(
-        std::move(src_zero_point_m));
-    IDEEP_ENFORCE(
-        param.sq_param_ptr,
-        "Failed to allocate memory for quantization parameters");
+    param.sq_param_ptr =
+        std::make_shared<deconv_forward_quant_params>(std::move(src_zero_point_m));
+    IDEEP_ENFORCE(param.sq_param_ptr, "Failed to allocate memory for quantization parameters");
   }
 
   // For fp32 and int8
   // `reorder_src` and `reorder_weight` indicate whether
   // src/dst and weight/bias should be checked and possibly reordered
   template <bool with_bias, bool reorder_src, bool reorder_weight>
-  static void do_compute(
-      const deconv_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
+  static void do_compute(const deconv_forward_params& param,
+                         const tensor& src,
+                         const tensor& weights,
+                         const tensor& bias,
+                         tensor& dst) {
     auto scratchpad = tensor(param.pd.scratchpad_desc());
     static tensor empty_src_zero_point;
-    auto& src_zero_point = param.sq_param_ptr
-        ? param.sq_param_ptr->src_zero_point
-        : empty_src_zero_point;
-    auto& expected_src =
-        reorder_src ? src.reorder_if_differ_in(param.pd.src_desc()) : src;
-    auto&& grouped_weights =
-        weights.make_grouped_weights(param.groups, /*is_deconv=*/true);
-    auto&& expected_weights = reorder_weight
-        ? grouped_weights.reorder_if_differ_in(param.pd.weights_desc())
-        : grouped_weights;
+    auto& src_zero_point = param.sq_param_ptr ?
+        param.sq_param_ptr->src_zero_point : empty_src_zero_point;
+    auto& expected_src = reorder_src ?
+        src.reorder_if_differ_in(param.pd.src_desc()) : src;
+    auto&& grouped_weights = weights.make_grouped_weights(param.groups, /*is_deconv=*/true);
+    auto&& expected_weights = reorder_weight ?
+        grouped_weights.reorder_if_differ_in(param.pd.weights_desc()) :
+        grouped_weights;
     if (reorder_src) {
       dst.reinit_if_possible(param.pd.dst_desc());
     }
     auto& primitive = param.primitive;
 
     if (with_bias) {
-      auto& expected_bias = reorder_weight
-          ? bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr)
-          : bias;
-      primitive.execute(
-          stream::default_stream(),
-          {{DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_WEIGHTS, expected_weights},
-           {DNNL_ARG_BIAS, expected_bias},
-           {DNNL_ARG_DST, dst},
-           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      auto& expected_bias = reorder_weight ?
+          bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr) :
+          bias;
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                        {DNNL_ARG_WEIGHTS, expected_weights},
+                        {DNNL_ARG_BIAS, expected_bias},
+                        {DNNL_ARG_DST, dst},
+                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
+                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      primitive.execute(
-          stream::default_stream(),
-          {{DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_WEIGHTS, expected_weights},
-           {DNNL_ARG_DST, dst},
-           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                        {DNNL_ARG_WEIGHTS, expected_weights},
+                        {DNNL_ARG_DST, dst},
+                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point},
+                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
+
 };
 
 struct convolution_transpose_backward_data
     : public dnnl::deconvolution_backward_data {
+
   using super = dnnl::deconvolution_backward_data;
 
-  static void compute(
-      const tensor& diff_dst,
-      const tensor& weights, // dim: {i, o[, d], h, w}
-      const dims& diff_src_dims,
-      tensor& diff_src,
-      const dims& strides,
-      const dims& padding_l,
-      const dims& padding_r,
-      const dims& dilates = {1, 1},
-      const int groups = 1,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::deconvolution_direct,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& diff_dst,
+                      const tensor& weights, // dim: {i, o[, d], h, w}
+                      const dims& diff_src_dims,
+                      tensor& diff_src,
+                      const dims& strides,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      const dims& dilates = {1, 1},
+                      const int groups = 1,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::deconvolution_direct,
+                      const engine& aengine = engine::cpu_engine()) {
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups, true);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -1111,131 +742,89 @@ struct convolution_transpose_backward_data
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
     auto weights_desc = weights_.get_desc().to_format_any();
 
-    tensor::desc diff_src_desc(
-        diff_src_dims, diff_dst_desc.get_data_type(), format_tag);
+    tensor::desc diff_src_desc(diff_src_dims, diff_dst_desc.get_data_type(), format_tag);
 
     auto op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto forward_hints =
         convolution_transpose_forward::get_primitive_desc</*with_bias=*/false>(
-            diff_src_desc,
-            weights_desc,
-            tensor::desc(),
-            diff_dst_desc,
-            strides,
-            dilates_,
-            padding_l,
-            padding_r,
-            op_attr);
+            diff_src_desc, weights_desc, tensor::desc(), diff_dst_desc, strides,
+            dilates_, padding_l, padding_r, op_attr);
 
     auto pd = primitive_desc(
-        {aalgorithm,
-         diff_src_desc,
-         weights_desc,
-         diff_dst_desc,
-         strides,
-         dilates_,
-         padding_l,
-         padding_r},
-        op_attr,
-        aengine,
-        forward_hints);
+        {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
+         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(
-        stream::default_stream(),
-        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-         {DNNL_ARG_WEIGHTS, expected_weights},
-         {DNNL_ARG_DIFF_SRC, diff_src},
-         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(stream::default_stream(),
+                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+                      {DNNL_ARG_WEIGHTS, expected_weights},
+                      {DNNL_ARG_DIFF_SRC, diff_src},
+                      {DNNL_ARG_SCRATCHPAD, scratchpad}});
   }
 };
 
 struct convolution_transpose_backward_weights
     : public dnnl::deconvolution_backward_weights {
+
   using super = dnnl::deconvolution_backward_weights;
 
-  static void compute(
-      const tensor& src,
-      const tensor& diff_dst,
-      const dims& diff_weights_dims,
-      tensor& diff_weights,
-      tensor& diff_bias,
-      const dims& strides,
-      const dims& padding_l,
-      const dims& padding_r,
-      const dims& dilates = {1, 1},
-      const int groups = 1,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::deconvolution_direct,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& diff_dst,
+                      const dims& diff_weights_dims,
+                      tensor& diff_weights,
+                      tensor& diff_bias,
+                      const dims& strides,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      const dims& dilates = {1, 1},
+                      const int groups = 1,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::deconvolution_direct,
+                      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*with_diff_bias=*/true>(
-        src,
-        diff_dst,
-        diff_weights_dims,
-        diff_weights,
-        diff_bias,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aengine);
+        src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
+        strides, dilates, padding_l, padding_r, groups, attr, aalgorithm, aengine);
   }
 
-  static void compute(
-      const tensor& src,
-      const tensor& diff_dst,
-      const dims& diff_weights_dims,
-      tensor& diff_weights,
-      const dims& strides,
-      const dims& padding_l,
-      const dims& padding_r,
-      const dims& dilates = {1, 1},
-      const int groups = 1,
-      const attr_t& attr = attr_t(),
-      algorithm aalgorithm = algorithm::deconvolution_direct,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& diff_dst,
+                      const dims& diff_weights_dims,
+                      tensor& diff_weights,
+                      const dims& strides,
+                      const dims& padding_l,
+                      const dims& padding_r,
+                      const dims& dilates = {1, 1},
+                      const int groups = 1,
+                      const attr_t& attr = attr_t(),
+                      algorithm aalgorithm = algorithm::deconvolution_direct,
+                      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
-        src,
-        diff_dst,
-        diff_weights_dims,
-        diff_weights,
-        dummy_diff_bias,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        groups,
-        attr,
-        aalgorithm,
-        aengine);
+        src, diff_dst, diff_weights_dims, diff_weights, dummy_diff_bias,
+        strides, dilates, padding_l, padding_r, groups, attr, aalgorithm, aengine);
   }
-
  private:
   template <bool with_diff_bias>
-  static void compute_impl(
-      const tensor& src,
-      const tensor& diff_dst,
-      const dims& diff_weights_dims, // [i, o, ...]
-      tensor& diff_weights,
-      tensor& diff_bias,
-      const dims& strides,
-      const dims& dilates,
-      const dims& padding_l,
-      const dims& padding_r,
-      const int groups,
-      const attr_t& attr,
-      algorithm aalgorithm,
-      const engine& aengine) {
+  static void compute_impl(const tensor& src,
+                           const tensor& diff_dst,
+                           const dims& diff_weights_dims, // [i, o, ...]
+                           tensor& diff_weights,
+                           tensor& diff_bias,
+                           const dims& strides,
+                           const dims& dilates,
+                           const dims& padding_l,
+                           const dims& padding_r,
+                           const int groups,
+                           const attr_t& attr,
+                           algorithm aalgorithm,
+                           const engine& aengine) {
+
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
 
@@ -1267,44 +856,17 @@ struct convolution_transpose_backward_weights
 
     auto forward_hints =
         convolution_transpose_forward::get_primitive_desc<with_diff_bias>(
-            src_desc,
-            diff_weights_desc,
-            diff_bias_desc,
-            diff_dst_desc,
-            strides,
-            dilates_,
-            padding_l,
-            padding_r,
-            op_attr,
-            aalgorithm,
-            prop_kind::forward,
-            aengine);
+            src_desc, diff_weights_desc, diff_bias_desc, diff_dst_desc, strides,
+            dilates_, padding_l, padding_r, op_attr, aalgorithm,
+            prop_kind::forward, aengine);
 
-    auto pd = with_diff_bias ? primitive_desc(
-                                   {aalgorithm,
-                                    src_desc,
-                                    diff_weights_desc,
-                                    diff_bias_desc,
-                                    diff_dst_desc,
-                                    strides,
-                                    dilates_,
-                                    padding_l,
-                                    padding_r},
-                                   op_attr,
-                                   aengine,
-                                   forward_hints)
-                             : primitive_desc(
-                                   {aalgorithm,
-                                    src_desc,
-                                    diff_weights_desc,
-                                    diff_dst_desc,
-                                    strides,
-                                    dilates_,
-                                    padding_l,
-                                    padding_r},
-                                   op_attr,
-                                   aengine,
-                                   forward_hints);
+    auto pd = with_diff_bias
+        ? primitive_desc({aalgorithm, src_desc, diff_weights_desc,
+                          diff_bias_desc, diff_dst_desc, strides, dilates_,
+                          padding_l, padding_r}, op_attr, aengine, forward_hints)
+        : primitive_desc({aalgorithm, src_desc, diff_weights_desc,
+                          diff_dst_desc, strides, dilates_,
+                          padding_l, padding_r}, op_attr, aengine, forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
@@ -1324,20 +886,18 @@ struct convolution_transpose_backward_weights
 
     if (with_diff_bias) {
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
-      super(pd).execute(
-          stream::default_stream(),
-          {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-           {DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-           {DNNL_ARG_DIFF_BIAS, diff_bias},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(stream::default_stream(),
+                        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+                        {DNNL_ARG_SRC, expected_src},
+                        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+                        {DNNL_ARG_DIFF_BIAS, diff_bias},
+                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      super(pd).execute(
-          stream::default_stream(),
-          {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-           {DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      super(pd).execute(stream::default_stream(),
+                        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+                        {DNNL_ARG_SRC, expected_src},
+                        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
 
     diff_weights.feed_from(expected_diff_weights, /*is_deconv_weights=*/true);
@@ -1352,6 +912,6 @@ struct convolution_transpose_backward_weights
     }
   }
 };
-} // namespace ideep
+}  // namespace ideep
 
 #endif

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -39,27 +39,25 @@ struct inner_product_forward
 
   // 2-in-1 compute, with bias
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst,
-      const attr_t& attr = attr_t(),
-      const prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor &src,
+                      const tensor &weights,
+                      const tensor &bias,
+                      tensor &dst,
+                      const attr_t &attr = attr_t(),
+                      const prop_kind aprop_kind = prop_kind::forward,
+                      const engine &aengine = engine::cpu_engine()) {
     compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
         src, weights, bias, dst, attr, aprop_kind, aengine);
   }
 
   // 2-in-1 compute, without bias
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const tensor& src,
-      const tensor& weights,
-      tensor& dst,
-      const attr_t& attr = attr_t(),
-      const prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor &src,
+                      const tensor &weights,
+                      tensor &dst,
+                      const attr_t &attr = attr_t(),
+                      const prop_kind aprop_kind = prop_kind::forward,
+                      const engine &aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
         src, weights, dummy_bias, dst, attr, aprop_kind, aengine);
@@ -67,66 +65,62 @@ struct inner_product_forward
 
   // 2-in-1 compute, with bias
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst,
-      const attr_t& attr = attr_t(),
-      const prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute_binary(const tensor &src,
+                             const tensor &other,
+                             const tensor &weights,
+                             const tensor &bias,
+                             tensor &dst,
+                             const attr_t &attr = attr_t(),
+                             const prop_kind aprop_kind = prop_kind::forward,
+                             const engine &aengine = engine::cpu_engine()) {
     inner_product_forward_params param;
-    do_prepare_<true>(
-        param, src, weights, bias, dst, attr, aprop_kind, aengine);
+    do_prepare_<true>(param, src, weights, bias, dst, attr, aprop_kind,
+                      aengine);
     do_compute_binary<true, reorder_src, reorder_weight>(
         param, src, other, weights, bias, dst);
   }
 
   // 2-in-1 compute, without bias
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      tensor& dst,
-      const attr_t& attr = attr_t(),
-      const prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute_binary(const tensor &src,
+                             const tensor &other,
+                             const tensor &weights,
+                             tensor &dst,
+                             const attr_t &attr = attr_t(),
+                             const prop_kind aprop_kind = prop_kind::forward,
+                             const engine &aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     inner_product_forward_params param;
-    do_prepare_<false>(
-        param, src, weights, dummy_bias, dst, attr, aprop_kind, aengine);
+    do_prepare_<false>(param, src, weights, dummy_bias, dst, attr, aprop_kind,
+                       aengine);
     do_compute_binary<false, reorder_src, reorder_weight>(
         param, src, other, weights, dummy_bias, dst);
   }
 
   // Prepare with bias
-  static void prepare(
-      inner_product_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst,
-      const attr_t& attr = attr_t(),
-      const prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
-    do_prepare</*with_bias=*/true>(
-        param, src, weights, bias, dst, attr, aprop_kind, aengine);
+  static void prepare(inner_product_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst,
+                      const attr_t& attr = attr_t(),
+                      const prop_kind aprop_kind = prop_kind::forward,
+                      const engine& aengine = engine::cpu_engine()) {
+    do_prepare</*with_bias=*/true>(param, src, weights, bias, dst, attr,
+                                   aprop_kind, aengine);
   }
 
   // Prepare without bias
-  static void prepare(
-      inner_product_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      tensor& dst,
-      const attr_t& attr = attr_t(),
-      const prop_kind aprop_kind = prop_kind::forward,
-      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(inner_product_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      tensor& dst,
+                      const attr_t& attr = attr_t(),
+                      const prop_kind aprop_kind = prop_kind::forward,
+                      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    do_prepare</*with_bias=*/false>(
-        param, src, weights, dummy_bias, dst, attr, aprop_kind, aengine);
+    do_prepare</*with_bias=*/false>(param, src, weights, dummy_bias, dst, attr,
+                                   aprop_kind, aengine);
   }
 
   // Compute with prepared param, with bias
@@ -134,12 +128,11 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const inner_product_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
+  static void compute(const inner_product_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst) {
     do_compute</*with_bias=*/true, reorder_src, reorder_weight>(
         param, src, weights, bias, dst);
   }
@@ -149,11 +142,10 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(
-      const inner_product_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      tensor& dst) {
+  static void compute(const inner_product_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      tensor& dst) {
     static tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -164,13 +156,12 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(
-      const inner_product_forward_params& param,
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
+  static void compute_binary(const inner_product_forward_params &param,
+                             const tensor &src,
+                             const tensor &other,
+                             const tensor &weights,
+                             const tensor &bias,
+                             tensor &dst) {
     do_compute_binary</*with_bias=*/true, reorder_src, reorder_weight>(
         param, src, other, weights, bias, dst);
   }
@@ -180,12 +171,11 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(
-      const inner_product_forward_params& param,
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      tensor& dst) {
+  static void compute_binary(const inner_product_forward_params &param,
+                             const tensor &src,
+                             const tensor &other,
+                             const tensor &weights,
+                             tensor &dst) {
     static tensor dummy_bias;
     do_compute_binary</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, other, weights, dummy_bias, dst);
@@ -240,9 +230,8 @@ struct inner_product_forward
     auto y_dims = {x_dims[0], weights_dims[0]};
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 
-    IDEEP_ENFORCE(
-        x_dims.size() == weights_dims.size(),
-        "Invalid dims for data and weights");
+    IDEEP_ENFORCE(x_dims.size() == weights_dims.size(),
+                  "Invalid dims for data and weights");
     tensor::desc src_desc(x_dims, x_dtype, tag::any);
     tensor::desc dst_desc(y_dims, y_dtype, tag::any);
     tensor::desc weights_desc(weights_dims, dtype, tag::any);
@@ -284,14 +273,13 @@ struct inner_product_forward
 
  private:
   template <bool with_bias, bool reorder_src = true, bool reorder_weight = true>
-  static void compute_impl(
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst,
-      const attr_t& attr,
-      const prop_kind aprop_kind,
-      const engine& aengine) {
+  static void compute_impl(const tensor &src,
+                           const tensor &weights,
+                           const tensor &bias,
+                           tensor &dst,
+                           const attr_t &attr,
+                           const prop_kind aprop_kind,
+                           const engine &aengine) {
     inner_product_forward_params param;
     // workaround: src and weights from caffe2 may have different dims.
     // It would be better for caffe2 to do this reshape anyway.
@@ -300,15 +288,15 @@ struct inner_product_forward
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
-      do_prepare_<with_bias>(
-          param, src_, weights, bias, dst, attr, aprop_kind, aengine);
-      do_compute_<with_bias, reorder_src, reorder_weight>(
-          param, src_, weights, bias, dst);
+      do_prepare_<with_bias>(param, src_, weights, bias, dst, attr, aprop_kind,
+                             aengine);
+      do_compute_<with_bias, reorder_src, reorder_weight>(param, src_, weights,
+                                                          bias, dst);
     } else {
-      do_prepare_<with_bias>(
-          param, src, weights, bias, dst, attr, aprop_kind, aengine);
-      do_compute_<with_bias, reorder_src, reorder_weight>(
-          param, src, weights, bias, dst);
+      do_prepare_<with_bias>(param, src, weights, bias, dst, attr, aprop_kind,
+                             aengine);
+      do_compute_<with_bias, reorder_src, reorder_weight>(param, src, weights,
+                                                          bias, dst);
     }
   }
 
@@ -329,11 +317,9 @@ struct inner_product_forward
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
-      do_prepare_<with_bias>(
-          param, src_, weights, bias, dst, attr, aprop_kind, aengine);
+      do_prepare_<with_bias>(param, src_, weights, bias, dst, attr, aprop_kind, aengine);
     } else {
-      do_prepare_<with_bias>(
-          param, src, weights, bias, dst, attr, aprop_kind, aengine);
+      do_prepare_<with_bias>(param, src, weights, bias, dst, attr, aprop_kind, aengine);
     }
   }
 
@@ -361,9 +347,9 @@ struct inner_product_forward
       src_attr = {0, src_scale};
     }
 
-    IDEEP_ENFORCE(
-        utils::one_of(weights.get_data_type(), data_type::f32, data_type::bf16),
-        "Incorrect data type in weights");
+    IDEEP_ENFORCE(utils::one_of(weights.get_data_type(),
+                                data_type::f32, data_type::bf16),
+            "Incorrect data type in weights");
 
     // align weights data type with src
     dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
@@ -371,9 +357,9 @@ struct inner_product_forward
     src_desc = {src.get_dims(), dst_data_type, format_tag::any};
     weights_desc = {weights.get_dims(), dst_data_type, format_tag::any};
     if (with_bias) {
-      IDEEP_ENFORCE(
-          utils::one_of(bias.get_data_type(), data_type::f32, data_type::bf16),
-          "Incorrect data type in bias");
+      IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
+                                  data_type::f32, data_type::bf16),
+                    "Incorrect data type in bias");
       bias_desc = bias.get_desc().to_format_any();
     }
 
@@ -409,11 +395,9 @@ struct inner_product_forward
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
-      do_compute_<with_bias, reorder_src, reorder_weight>(
-          param, src_, weights, bias, dst);
+      do_compute_<with_bias, reorder_src, reorder_weight>(param, src_, weights, bias, dst);
     } else {
-      do_compute_<with_bias, reorder_src, reorder_weight>(
-          param, src, weights, bias, dst);
+      do_compute_<with_bias, reorder_src, reorder_weight>(param, src, weights, bias, dst);
     }
   }
 
@@ -421,29 +405,29 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed. Used for binary fusion
   template <bool with_bias, bool reorder_src = true, bool reorder_weight = true>
-  static void do_compute_binary(
-      const inner_product_forward_params& param,
-      const tensor& src,
-      const tensor& other,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
-    auto& pd = param.pd;
-    auto& primitive = param.primitive;
-    auto& op_attr = param.op_attr;
-    auto& src_attr = param.src_attr;
-    auto& weights_attr = param.weights_attr;
-    auto& bias_attr = param.bias_attr;
+  static void do_compute_binary(const inner_product_forward_params &param,
+                                const tensor &src,
+                                const tensor &other,
+                                const tensor &weights,
+                                const tensor &bias,
+                                tensor &dst) {
+    auto &pd = param.pd;
+    auto &primitive = param.primitive;
+    auto &op_attr = param.op_attr;
+    auto &src_attr = param.src_attr;
+    auto &weights_attr = param.weights_attr;
+    auto &bias_attr = param.bias_attr;
 
-    auto& expected_src =
+    auto &expected_src =
         reorder_src ? src.reorder_if_differ_in(pd.src_desc(), src_attr) : src;
     // make sure other has same format with dst.
     // TODO: other has different with dst?
-    auto& expected_other =
+    auto &expected_other =
         reorder_src ? other.reorder_if_differ_in(pd.dst_desc()) : other;
-    auto& expected_weights = reorder_weight
-        ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
-        : weights;
+    auto &expected_weights =
+        reorder_weight
+            ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
+            : weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     exec_args args;
@@ -508,11 +492,12 @@ struct inner_product_forward
     auto& weights_attr = param.weights_attr;
     auto& bias_attr = param.bias_attr;
 
-    auto& expected_src =
-        reorder_src ? src.reorder_if_differ_in(pd.src_desc(), src_attr) : src;
-    auto& expected_weights = reorder_weight
-        ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
-        : weights;
+    auto& expected_src = reorder_src ?
+        src.reorder_if_differ_in(pd.src_desc(), src_attr) :
+        src;
+    auto& expected_weights = reorder_weight ?
+        weights.reorder_if_differ_in(pd.weights_desc(), weights_attr) :
+        weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     exec_args args;
@@ -527,7 +512,7 @@ struct inner_product_forward
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
     if (reorder_src) {
       tensor expected_dst;
-      if (dst.is_empty() || dst.get_desc() != pd.dst_desc()) {
+      if (dst.is_empty() || dst.get_desc() != pd.dst_desc()){
         // If dst buffer are not given by user or user given dst buffer are not
         // under expected format We need init a new one. "dst.get_desc() !=
         // pd.dst_desc()" conditional is setting for caffe2 caller, it might
@@ -549,10 +534,9 @@ struct inner_product_forward
           // when dst is empty, expect return buffer allocate by ideep
           dst.get_desc() == expected_dst.get_desc() ||
           // dst and expected_dst is the same under this case
-          !dst.get_desc().has_same_shape_as(expected_dst.get_desc())) {
-        // for caffe2 caller, get an uncorrect size dst from caller, can return
-        // buffer allocate by ideep
-        dst = expected_dst;
+          !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
+          // for caffe2 caller, get an uncorrect size dst from caller, can return buffer allocate by ideep
+        dst =  expected_dst;
       } else {
         dst.feed_from(expected_dst);
       }
@@ -563,16 +547,17 @@ struct inner_product_forward
   }
 };
 
+
 struct inner_product_backward_data : public dnnl::inner_product_backward_data {
+
   using super = dnnl::inner_product_backward_data;
 
-  static void compute(
-      const tensor& diff_dst,
-      const tensor& weights,
-      const dims& diff_src_dims,
-      tensor& diff_src,
-      const attr_t& attr = attr_t(),
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& diff_dst,
+                      const tensor& weights,
+                      const dims& diff_src_dims,
+                      tensor& diff_src,
+                      const attr_t& attr = attr_t(),
+                      const engine& aengine = engine::cpu_engine()) {
     auto weights_ = weights;
     if (diff_dst.get_data_type() == data_type::bf16) {
       weights_.init(weights.get_desc().to_type(data_type::bf16));
@@ -599,17 +584,14 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
         diff_src_desc, weights_desc, diff_dst_desc, tensor::desc(), false, op_attr);
 
     auto pd = primitive_desc(
-        {diff_src_desc, weights_desc, diff_dst_desc},
-        op_attr,
-        aengine,
-        forward_hints);
+        {diff_src_desc, weights_desc, diff_dst_desc}, op_attr, aengine, forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
     tensor expected_diff_src;
-    if (diff_src.is_empty() || diff_src.get_desc() != pd.diff_src_desc()) {
-      // If diff_src buffer are not given by user or user given diff_src buffer
-      // are not under expected format We need init a new one
+    if (diff_src.is_empty() || diff_src.get_desc() != pd.diff_src_desc()){
+      // If diff_src buffer are not given by user or user given diff_src buffer are not under expected format
+      // We need init a new one
       expected_diff_src.init(pd.diff_src_desc());
     } else {
       // The format of given diff_src buffer is expected
@@ -618,16 +600,15 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(
-        stream::default_stream(),
-        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-         {DNNL_ARG_WEIGHTS, expected_weights},
-         {DNNL_ARG_DIFF_SRC, expected_diff_src},
-         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(stream::default_stream(),
+                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+                       {DNNL_ARG_WEIGHTS, expected_weights},
+                       {DNNL_ARG_DIFF_SRC, expected_diff_src},
+                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
     // reorder back to diff_src's buffer if needed
     if (diff_src.is_empty() ||
-        diff_src.get_desc() == expected_diff_src.get_desc() ||
-        !diff_src.get_desc().has_same_shape_as(expected_diff_src.get_desc())) {
+         diff_src.get_desc() == expected_diff_src.get_desc() ||
+         !diff_src.get_desc().has_same_shape_as(expected_diff_src.get_desc())){
       diff_src = expected_diff_src;
     } else {
       diff_src.feed_from(expected_diff_src);
@@ -637,49 +618,47 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
 
 struct inner_product_backward_weights
     : public dnnl::inner_product_backward_weights {
+
   using super = dnnl::inner_product_backward_weights;
 
-  static void compute(
-      const tensor& src,
-      const tensor& diff_dst,
-      tensor& diff_weights,
-      tensor& diff_bias,
-      const data_type diff_weight_type = data_type::undef,
-      const attr_t& attr = attr_t(),
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& diff_dst,
+                      tensor& diff_weights,
+                      tensor& diff_bias,
+                      const data_type diff_weight_type = data_type::undef,
+                      const attr_t& attr = attr_t(),
+                      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*with_diff_bias=*/true>(
         src, diff_dst, diff_weights, diff_bias, diff_weight_type, attr);
   }
 
-  static void compute(
-      const tensor& src,
-      const tensor& diff_dst,
-      tensor& diff_weights,
-      const data_type diff_weight_type = data_type::undef,
-      const attr_t& attr = attr_t(),
-      const engine& aengine = engine::cpu_engine()) {
+  static void compute(const tensor& src,
+                      const tensor& diff_dst,
+                      tensor& diff_weights,
+                      const data_type diff_weight_type = data_type::undef,
+                      const attr_t& attr = attr_t(),
+                      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
         src, diff_dst, diff_weights, dummy_diff_bias, diff_weight_type, attr);
   }
 
  private:
-  template <bool with_diff_bias = true>
-  static void compute_impl(
-      const tensor& src,
-      const tensor& diff_dst,
-      tensor& diff_weights,
-      tensor& diff_bias,
-      const data_type diff_weight_type,
-      const attr_t& attr = attr_t(),
-      const engine& aengine = engine::cpu_engine()) {
+  template<bool with_diff_bias = true>
+  static void compute_impl(const tensor& src,
+                           const tensor& diff_dst,
+                           tensor& diff_weights,
+                           tensor& diff_bias,
+                           const data_type diff_weight_type,
+                           const attr_t& attr = attr_t(),
+                           const engine& aengine = engine::cpu_engine()) {
     auto src_desc = src.get_desc().to_format_any();
     auto diff_dst_desc = diff_dst.get_desc().to_format_any();
     auto diff_weights_dims = src.get_dims();
     diff_weights_dims[0] = diff_dst.get_dim(1);
     data_type diff_dst_type = diff_dst.get_data_type();
-    data_type diff_weight_type_in =
-        data_type::undef == diff_weight_type ? diff_dst_type : diff_weight_type;
+    data_type diff_weight_type_in = data_type::undef== diff_weight_type ?
+                                    diff_dst_type : diff_weight_type;
     auto diff_weights_desc =
         tensor::desc(diff_weights_dims, diff_weight_type_in, tag::any);
 
@@ -699,24 +678,17 @@ struct inner_product_backward_weights
         src_desc, weights_desc, diff_dst_desc, diff_bias_desc, with_diff_bias, op_attr);
 
     auto pd = with_diff_bias
-        ? primitive_desc(
-              {src_desc, diff_weights_desc, diff_bias_desc, diff_dst_desc},
-              op_attr,
-              aengine,
-              forward_hints)
-        : primitive_desc(
-              {src_desc, diff_weights_desc, diff_dst_desc},
-              op_attr,
-              aengine,
-              forward_hints);
+        ? primitive_desc({src_desc, diff_weights_desc, diff_bias_desc,
+                          diff_dst_desc}, op_attr, aengine, forward_hints)
+        : primitive_desc({src_desc, diff_weights_desc, diff_dst_desc},
+                          op_attr, aengine, forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     tensor expected_diff_weights;
-    if (diff_weights.is_empty() ||
-        diff_weights.get_desc() != pd.diff_weights_desc()) {
-      // If diff_weights buffer are not given by user or user given diff_weights
-      // buffer are not under expected format We need init a new one
+    if (diff_weights.is_empty() || diff_weights.get_desc() != pd.diff_weights_desc()){
+      // If diff_weights buffer are not given by user or user given diff_weights buffer are not under expected format
+      // We need init a new one
       expected_diff_weights.init(pd.diff_weights_desc());
     } else {
       // The format of given diff_weights buffer is expected
@@ -725,11 +697,10 @@ struct inner_product_backward_weights
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args{
-        {DNNL_ARG_DIFF_DST, expected_diff_dst},
-        {DNNL_ARG_SRC, expected_src},
-        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
-        {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+                    {DNNL_ARG_SRC, expected_src},
+                    {DNNL_ARG_DIFF_WEIGHTS ,expected_diff_weights},
+                    {DNNL_ARG_SCRATCHPAD, scratchpad}};
 
     if (with_diff_bias) {
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
@@ -739,9 +710,8 @@ struct inner_product_backward_weights
     super(pd).execute(stream::default_stream(), args);
     // reorder back to diff_weights's buffer if needed
     if (diff_weights.is_empty() ||
-        diff_weights.get_desc() == expected_diff_weights.get_desc() ||
-        !diff_weights.get_desc().has_same_shape_as(
-            expected_diff_weights.get_desc())) {
+         diff_weights.get_desc() == expected_diff_weights.get_desc() ||
+         !diff_weights.get_desc().has_same_shape_as(expected_diff_weights.get_desc())){
       diff_weights = expected_diff_weights;
     } else {
       diff_weights.feed_from(expected_diff_weights);
@@ -749,6 +719,6 @@ struct inner_product_backward_weights
   }
 };
 
-} // namespace ideep
+}  // namespace ideep
 
 #endif

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -39,25 +39,27 @@ struct inner_product_forward
 
   // 2-in-1 compute, with bias
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const tensor &src,
-                      const tensor &weights,
-                      const tensor &bias,
-                      tensor &dst,
-                      const attr_t &attr = attr_t(),
-                      const prop_kind aprop_kind = prop_kind::forward,
-                      const engine &aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
         src, weights, bias, dst, attr, aprop_kind, aengine);
   }
 
   // 2-in-1 compute, without bias
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const tensor &src,
-                      const tensor &weights,
-                      tensor &dst,
-                      const attr_t &attr = attr_t(),
-                      const prop_kind aprop_kind = prop_kind::forward,
-                      const engine &aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
         src, weights, dummy_bias, dst, attr, aprop_kind, aengine);
@@ -65,62 +67,66 @@ struct inner_product_forward
 
   // 2-in-1 compute, with bias
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(const tensor &src,
-                             const tensor &other,
-                             const tensor &weights,
-                             const tensor &bias,
-                             tensor &dst,
-                             const attr_t &attr = attr_t(),
-                             const prop_kind aprop_kind = prop_kind::forward,
-                             const engine &aengine = engine::cpu_engine()) {
+  static void compute_binary(
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     inner_product_forward_params param;
-    do_prepare_<true>(param, src, weights, bias, dst, attr, aprop_kind,
-                      aengine);
+    do_prepare_<true>(
+        param, src, weights, bias, dst, attr, aprop_kind, aengine);
     do_compute_binary<true, reorder_src, reorder_weight>(
         param, src, other, weights, bias, dst);
   }
 
   // 2-in-1 compute, without bias
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(const tensor &src,
-                             const tensor &other,
-                             const tensor &weights,
-                             tensor &dst,
-                             const attr_t &attr = attr_t(),
-                             const prop_kind aprop_kind = prop_kind::forward,
-                             const engine &aengine = engine::cpu_engine()) {
+  static void compute_binary(
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     inner_product_forward_params param;
-    do_prepare_<false>(param, src, weights, dummy_bias, dst, attr, aprop_kind,
-                       aengine);
+    do_prepare_<false>(
+        param, src, weights, dummy_bias, dst, attr, aprop_kind, aengine);
     do_compute_binary<false, reorder_src, reorder_weight>(
         param, src, other, weights, dummy_bias, dst);
   }
 
   // Prepare with bias
-  static void prepare(inner_product_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst,
-                      const attr_t& attr = attr_t(),
-                      const prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
-    do_prepare</*with_bias=*/true>(param, src, weights, bias, dst, attr,
-                                   aprop_kind, aengine);
+  static void prepare(
+      inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
+    do_prepare</*with_bias=*/true>(
+        param, src, weights, bias, dst, attr, aprop_kind, aengine);
   }
 
   // Prepare without bias
-  static void prepare(inner_product_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      tensor& dst,
-                      const attr_t& attr = attr_t(),
-                      const prop_kind aprop_kind = prop_kind::forward,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    do_prepare</*with_bias=*/false>(param, src, weights, dummy_bias, dst, attr,
-                                   aprop_kind, aengine);
+    do_prepare</*with_bias=*/false>(
+        param, src, weights, dummy_bias, dst, attr, aprop_kind, aengine);
   }
 
   // Compute with prepared param, with bias
@@ -128,11 +134,12 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const inner_product_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst) {
+  static void compute(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     do_compute</*with_bias=*/true, reorder_src, reorder_weight>(
         param, src, weights, bias, dst);
   }
@@ -142,10 +149,11 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute(const inner_product_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      tensor& dst) {
+  static void compute(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst) {
     static tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -156,12 +164,13 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(const inner_product_forward_params &param,
-                             const tensor &src,
-                             const tensor &other,
-                             const tensor &weights,
-                             const tensor &bias,
-                             tensor &dst) {
+  static void compute_binary(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     do_compute_binary</*with_bias=*/true, reorder_src, reorder_weight>(
         param, src, other, weights, bias, dst);
   }
@@ -171,11 +180,12 @@ struct inner_product_forward
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static void compute_binary(const inner_product_forward_params &param,
-                             const tensor &src,
-                             const tensor &other,
-                             const tensor &weights,
-                             tensor &dst) {
+  static void compute_binary(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      tensor& dst) {
     static tensor dummy_bias;
     do_compute_binary</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, other, weights, dummy_bias, dst);
@@ -230,8 +240,9 @@ struct inner_product_forward
     auto y_dims = {x_dims[0], weights_dims[0]};
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 
-    IDEEP_ENFORCE(x_dims.size() == weights_dims.size(),
-                  "Invalid dims for data and weights");
+    IDEEP_ENFORCE(
+        x_dims.size() == weights_dims.size(),
+        "Invalid dims for data and weights");
     tensor::desc src_desc(x_dims, x_dtype, tag::any);
     tensor::desc dst_desc(y_dims, y_dtype, tag::any);
     tensor::desc weights_desc(weights_dims, dtype, tag::any);
@@ -271,15 +282,16 @@ struct inner_product_forward
     });
   };
 
-private:
+ private:
   template <bool with_bias, bool reorder_src = true, bool reorder_weight = true>
-  static void compute_impl(const tensor &src,
-                           const tensor &weights,
-                           const tensor &bias,
-                           tensor &dst,
-                           const attr_t &attr,
-                           const prop_kind aprop_kind,
-                           const engine &aengine) {
+  static void compute_impl(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr,
+      const prop_kind aprop_kind,
+      const engine& aengine) {
     inner_product_forward_params param;
     // workaround: src and weights from caffe2 may have different dims.
     // It would be better for caffe2 to do this reshape anyway.
@@ -288,15 +300,15 @@ private:
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
-      do_prepare_<with_bias>(param, src_, weights, bias, dst, attr, aprop_kind,
-                             aengine);
-      do_compute_<with_bias, reorder_src, reorder_weight>(param, src_, weights,
-                                                          bias, dst);
+      do_prepare_<with_bias>(
+          param, src_, weights, bias, dst, attr, aprop_kind, aengine);
+      do_compute_<with_bias, reorder_src, reorder_weight>(
+          param, src_, weights, bias, dst);
     } else {
-      do_prepare_<with_bias>(param, src, weights, bias, dst, attr, aprop_kind,
-                             aengine);
-      do_compute_<with_bias, reorder_src, reorder_weight>(param, src, weights,
-                                                          bias, dst);
+      do_prepare_<with_bias>(
+          param, src, weights, bias, dst, attr, aprop_kind, aengine);
+      do_compute_<with_bias, reorder_src, reorder_weight>(
+          param, src, weights, bias, dst);
     }
   }
 
@@ -317,9 +329,11 @@ private:
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
-      do_prepare_<with_bias>(param, src_, weights, bias, dst, attr, aprop_kind, aengine);
+      do_prepare_<with_bias>(
+          param, src_, weights, bias, dst, attr, aprop_kind, aengine);
     } else {
-      do_prepare_<with_bias>(param, src, weights, bias, dst, attr, aprop_kind, aengine);
+      do_prepare_<with_bias>(
+          param, src, weights, bias, dst, attr, aprop_kind, aengine);
     }
   }
 
@@ -347,9 +361,9 @@ private:
       src_attr = {0, src_scale};
     }
 
-    IDEEP_ENFORCE(utils::one_of(weights.get_data_type(),
-                                data_type::f32, data_type::bf16),
-            "Incorrect data type in weights");
+    IDEEP_ENFORCE(
+        utils::one_of(weights.get_data_type(), data_type::f32, data_type::bf16),
+        "Incorrect data type in weights");
 
     // align weights data type with src
     dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
@@ -357,15 +371,14 @@ private:
     src_desc = {src.get_dims(), dst_data_type, format_tag::any};
     weights_desc = {weights.get_dims(), dst_data_type, format_tag::any};
     if (with_bias) {
-      IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
-                                  data_type::f32, data_type::bf16),
-                    "Incorrect data type in bias");
+      IDEEP_ENFORCE(
+          utils::one_of(bias.get_data_type(), data_type::f32, data_type::bf16),
+          "Incorrect data type in bias");
       bias_desc = bias.get_desc().to_format_any();
     }
 
     tensor::desc dst_desc(dst_dims, dst_data_type, format_tag::any);
 
-    op_attr.set_fpmath_mode();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     param.pd = get_primitive_desc(
@@ -396,9 +409,11 @@ private:
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
-      do_compute_<with_bias, reorder_src, reorder_weight>(param, src_, weights, bias, dst);
+      do_compute_<with_bias, reorder_src, reorder_weight>(
+          param, src_, weights, bias, dst);
     } else {
-      do_compute_<with_bias, reorder_src, reorder_weight>(param, src, weights, bias, dst);
+      do_compute_<with_bias, reorder_src, reorder_weight>(
+          param, src, weights, bias, dst);
     }
   }
 
@@ -406,42 +421,43 @@ private:
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed. Used for binary fusion
   template <bool with_bias, bool reorder_src = true, bool reorder_weight = true>
-  static void do_compute_binary(const inner_product_forward_params &param,
-                                const tensor &src,
-                                const tensor &other,
-                                const tensor &weights,
-                                const tensor &bias,
-                                tensor &dst) {
-    auto &pd = param.pd;
-    auto &primitive = param.primitive;
-    auto &op_attr = param.op_attr;
-    auto &src_attr = param.src_attr;
-    auto &weights_attr = param.weights_attr;
-    auto &bias_attr = param.bias_attr;
+  static void do_compute_binary(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& other,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
+    auto& pd = param.pd;
+    auto& primitive = param.primitive;
+    auto& op_attr = param.op_attr;
+    auto& src_attr = param.src_attr;
+    auto& weights_attr = param.weights_attr;
+    auto& bias_attr = param.bias_attr;
 
-    auto &expected_src =
+    auto& expected_src =
         reorder_src ? src.reorder_if_differ_in(pd.src_desc(), src_attr) : src;
     // make sure other has same format with dst.
     // TODO: other has different with dst?
-    auto &expected_other =
+    auto& expected_other =
         reorder_src ? other.reorder_if_differ_in(pd.dst_desc()) : other;
-    auto &expected_weights =
-        reorder_weight
-            ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
-            : weights;
+    auto& expected_weights = reorder_weight
+        ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
+        : weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     exec_args args;
     args.insert({DNNL_ARG_SRC, expected_src});
     args.insert({DNNL_ARG_WEIGHTS, expected_weights});
     if (with_bias) {
-      auto& expected_bias = reorder_weight ?
-                            bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                            bias;
+      auto& expected_bias = reorder_weight
+          ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
+          : bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
-    args.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, expected_other});
+    args.insert(
+        {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, expected_other});
     if (reorder_src) {
       tensor expected_dst;
       if (dst.is_empty() || dst.get_desc() != pd.dst_desc()) {
@@ -492,27 +508,26 @@ private:
     auto& weights_attr = param.weights_attr;
     auto& bias_attr = param.bias_attr;
 
-    auto& expected_src = reorder_src ?
-        src.reorder_if_differ_in(pd.src_desc(), src_attr) :
-        src;
-    auto& expected_weights = reorder_weight ?
-        weights.reorder_if_differ_in(pd.weights_desc(), weights_attr) :
-        weights;
+    auto& expected_src =
+        reorder_src ? src.reorder_if_differ_in(pd.src_desc(), src_attr) : src;
+    auto& expected_weights = reorder_weight
+        ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
+        : weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     exec_args args;
     args.insert({DNNL_ARG_SRC, expected_src});
     args.insert({DNNL_ARG_WEIGHTS, expected_weights});
     if (with_bias) {
-      auto& expected_bias = reorder_weight ?
-                            bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                            bias;
+      auto& expected_bias = reorder_weight
+          ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
+          : bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
     if (reorder_src) {
       tensor expected_dst;
-      if (dst.is_empty() || dst.get_desc() != pd.dst_desc()){
+      if (dst.is_empty() || dst.get_desc() != pd.dst_desc()) {
         // If dst buffer are not given by user or user given dst buffer are not
         // under expected format We need init a new one. "dst.get_desc() !=
         // pd.dst_desc()" conditional is setting for caffe2 caller, it might
@@ -534,9 +549,10 @@ private:
           // when dst is empty, expect return buffer allocate by ideep
           dst.get_desc() == expected_dst.get_desc() ||
           // dst and expected_dst is the same under this case
-          !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
-          // for caffe2 caller, get an uncorrect size dst from caller, can return buffer allocate by ideep
-        dst =  expected_dst;
+          !dst.get_desc().has_same_shape_as(expected_dst.get_desc())) {
+        // for caffe2 caller, get an uncorrect size dst from caller, can return
+        // buffer allocate by ideep
+        dst = expected_dst;
       } else {
         dst.feed_from(expected_dst);
       }
@@ -547,16 +563,16 @@ private:
   }
 };
 
-
 struct inner_product_backward_data : public dnnl::inner_product_backward_data {
-
   using super = dnnl::inner_product_backward_data;
 
-  static void compute(const tensor& diff_dst,
-                      const tensor& weights,
-                      const dims& diff_src_dims,
-                      tensor& diff_src,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& diff_dst,
+      const tensor& weights,
+      const dims& diff_src_dims,
+      tensor& diff_src,
+      const attr_t& attr = attr_t(),
+      const engine& aengine = engine::cpu_engine()) {
     auto weights_ = weights;
     if (diff_dst.get_data_type() == data_type::bf16) {
       weights_.init(weights.get_desc().to_type(data_type::bf16));
@@ -576,22 +592,24 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
     auto diff_src_desc =
         tensor::desc(diff_src_dims, diff_dst.get_data_type(), tag::any);
 
-    auto forward_hints = inner_product_forward::get_primitive_desc(
-        diff_src_desc, weights_desc, diff_dst_desc);
-
-    auto op_attr = ideep::attr_t();
-    op_attr.set_fpmath_mode();
+    auto op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
+    auto forward_hints = inner_product_forward::get_primitive_desc(
+        diff_src_desc, weights_desc, diff_dst_desc, tensor::desc(), false, op_attr);
+
     auto pd = primitive_desc(
-        {diff_src_desc, weights_desc, diff_dst_desc}, op_attr, aengine, forward_hints);
+        {diff_src_desc, weights_desc, diff_dst_desc},
+        op_attr,
+        aengine,
+        forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
     tensor expected_diff_src;
-    if (diff_src.is_empty() || diff_src.get_desc() != pd.diff_src_desc()){
-      // If diff_src buffer are not given by user or user given diff_src buffer are not under expected format
-      // We need init a new one
+    if (diff_src.is_empty() || diff_src.get_desc() != pd.diff_src_desc()) {
+      // If diff_src buffer are not given by user or user given diff_src buffer
+      // are not under expected format We need init a new one
       expected_diff_src.init(pd.diff_src_desc());
     } else {
       // The format of given diff_src buffer is expected
@@ -600,15 +618,16 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    super(pd).execute(stream::default_stream(),
-                      {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                       {DNNL_ARG_WEIGHTS, expected_weights},
-                       {DNNL_ARG_DIFF_SRC, expected_diff_src},
-                       {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_DIFF_DST, expected_diff_dst},
+         {DNNL_ARG_WEIGHTS, expected_weights},
+         {DNNL_ARG_DIFF_SRC, expected_diff_src},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
     // reorder back to diff_src's buffer if needed
     if (diff_src.is_empty() ||
-         diff_src.get_desc() == expected_diff_src.get_desc() ||
-         !diff_src.get_desc().has_same_shape_as(expected_diff_src.get_desc())){
+        diff_src.get_desc() == expected_diff_src.get_desc() ||
+        !diff_src.get_desc().has_same_shape_as(expected_diff_src.get_desc())) {
       diff_src = expected_diff_src;
     } else {
       diff_src.feed_from(expected_diff_src);
@@ -618,44 +637,49 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
 
 struct inner_product_backward_weights
     : public dnnl::inner_product_backward_weights {
-
   using super = dnnl::inner_product_backward_weights;
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      tensor& diff_weights,
-                      tensor& diff_bias,
-                      const data_type diff_weight_type = data_type::undef,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const data_type diff_weight_type = data_type::undef,
+      const attr_t& attr = attr_t(),
+      const engine& aengine = engine::cpu_engine()) {
     compute_impl</*with_diff_bias=*/true>(
-        src, diff_dst, diff_weights, diff_bias, diff_weight_type);
+        src, diff_dst, diff_weights, diff_bias, diff_weight_type, attr);
   }
 
-  static void compute(const tensor& src,
-                      const tensor& diff_dst,
-                      tensor& diff_weights,
-                      const data_type diff_weight_type = data_type::undef,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void compute(
+      const tensor& src,
+      const tensor& diff_dst,
+      tensor& diff_weights,
+      const data_type diff_weight_type = data_type::undef,
+      const attr_t& attr = attr_t(),
+      const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
-        src, diff_dst, diff_weights, dummy_diff_bias, diff_weight_type);
+        src, diff_dst, diff_weights, dummy_diff_bias, diff_weight_type, attr);
   }
 
-private:
-  template<bool with_diff_bias = true>
-  static void compute_impl(const tensor& src,
-                           const tensor& diff_dst,
-                           tensor& diff_weights,
-                           tensor& diff_bias,
-                           const data_type diff_weight_type,
-                           const engine& aengine = engine::cpu_engine()) {
+ private:
+  template <bool with_diff_bias = true>
+  static void compute_impl(
+      const tensor& src,
+      const tensor& diff_dst,
+      tensor& diff_weights,
+      tensor& diff_bias,
+      const data_type diff_weight_type,
+      const attr_t& attr = attr_t(),
+      const engine& aengine = engine::cpu_engine()) {
     auto src_desc = src.get_desc().to_format_any();
     auto diff_dst_desc = diff_dst.get_desc().to_format_any();
     auto diff_weights_dims = src.get_dims();
     diff_weights_dims[0] = diff_dst.get_dim(1);
     data_type diff_dst_type = diff_dst.get_data_type();
-    data_type diff_weight_type_in = data_type::undef== diff_weight_type ?
-                                    diff_dst_type : diff_weight_type;
+    data_type diff_weight_type_in =
+        data_type::undef == diff_weight_type ? diff_dst_type : diff_weight_type;
     auto diff_weights_desc =
         tensor::desc(diff_weights_dims, diff_weight_type_in, tag::any);
 
@@ -668,25 +692,31 @@ private:
     if (diff_weight_type_in != diff_dst_type) {
       weights_desc = weights_desc.to_type(diff_dst_type);
     }
-    auto forward_hints = inner_product_forward::get_primitive_desc(
-        src_desc, weights_desc, diff_dst_desc, diff_bias_desc, with_diff_bias);
-
-    auto op_attr = ideep::attr_t();
-    op_attr.set_fpmath_mode();
+    auto op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
+    auto forward_hints = inner_product_forward::get_primitive_desc(
+        src_desc, weights_desc, diff_dst_desc, diff_bias_desc, with_diff_bias, op_attr);
+
     auto pd = with_diff_bias
-        ? primitive_desc({src_desc, diff_weights_desc, diff_bias_desc,
-                          diff_dst_desc}, op_attr, aengine, forward_hints)
-        : primitive_desc({src_desc, diff_weights_desc, diff_dst_desc},
-                          op_attr, aengine, forward_hints);
+        ? primitive_desc(
+              {src_desc, diff_weights_desc, diff_bias_desc, diff_dst_desc},
+              op_attr,
+              aengine,
+              forward_hints)
+        : primitive_desc(
+              {src_desc, diff_weights_desc, diff_dst_desc},
+              op_attr,
+              aengine,
+              forward_hints);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     tensor expected_diff_weights;
-    if (diff_weights.is_empty() || diff_weights.get_desc() != pd.diff_weights_desc()){
-      // If diff_weights buffer are not given by user or user given diff_weights buffer are not under expected format
-      // We need init a new one
+    if (diff_weights.is_empty() ||
+        diff_weights.get_desc() != pd.diff_weights_desc()) {
+      // If diff_weights buffer are not given by user or user given diff_weights
+      // buffer are not under expected format We need init a new one
       expected_diff_weights.init(pd.diff_weights_desc());
     } else {
       // The format of given diff_weights buffer is expected
@@ -695,10 +725,11 @@ private:
 
     tensor scratchpad(pd.scratchpad_desc());
 
-    exec_args args {{DNNL_ARG_DIFF_DST, expected_diff_dst},
-                    {DNNL_ARG_SRC, expected_src},
-                    {DNNL_ARG_DIFF_WEIGHTS ,expected_diff_weights},
-                    {DNNL_ARG_SCRATCHPAD, scratchpad}};
+    exec_args args{
+        {DNNL_ARG_DIFF_DST, expected_diff_dst},
+        {DNNL_ARG_SRC, expected_src},
+        {DNNL_ARG_DIFF_WEIGHTS, expected_diff_weights},
+        {DNNL_ARG_SCRATCHPAD, scratchpad}};
 
     if (with_diff_bias) {
       diff_bias.reinit_if_possible(pd.diff_bias_desc());
@@ -706,10 +737,11 @@ private:
     }
 
     super(pd).execute(stream::default_stream(), args);
-      // reorder back to diff_weights's buffer if needed
+    // reorder back to diff_weights's buffer if needed
     if (diff_weights.is_empty() ||
-         diff_weights.get_desc() == expected_diff_weights.get_desc() ||
-         !diff_weights.get_desc().has_same_shape_as(expected_diff_weights.get_desc())){
+        diff_weights.get_desc() == expected_diff_weights.get_desc() ||
+        !diff_weights.get_desc().has_same_shape_as(
+            expected_diff_weights.get_desc())) {
       diff_weights = expected_diff_weights;
     } else {
       diff_weights.feed_from(expected_diff_weights);
@@ -717,6 +749,6 @@ private:
   }
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -271,7 +271,7 @@ struct inner_product_forward
     });
   };
 
- private:
+private:
   template <bool with_bias, bool reorder_src = true, bool reorder_weight = true>
   static void compute_impl(const tensor &src,
                            const tensor &weights,
@@ -643,7 +643,7 @@ struct inner_product_backward_weights
         src, diff_dst, diff_weights, dummy_diff_bias, diff_weight_type, attr);
   }
 
- private:
+private:
   template<bool with_diff_bias = true>
   static void compute_impl(const tensor& src,
                            const tensor& diff_dst,
@@ -708,7 +708,7 @@ struct inner_product_backward_weights
     }
 
     super(pd).execute(stream::default_stream(), args);
-    // reorder back to diff_weights's buffer if needed
+      // reorder back to diff_weights's buffer if needed
     if (diff_weights.is_empty() ||
          diff_weights.get_desc() == expected_diff_weights.get_desc() ||
          !diff_weights.get_desc().has_same_shape_as(expected_diff_weights.get_desc())){

--- a/include/ideep/operators/lstm.hpp
+++ b/include/ideep/operators/lstm.hpp
@@ -3,12 +3,417 @@
 
 namespace ideep {
 
-struct lstm_forward : public dnnl::lstm_forward {
-  static void compute() {}
+struct lstm_forward_inference : public dnnl::lstm_forward {
+  using super = dnnl::lstm_forward;
+
+  static void compute(
+      const tensor& src_layer,
+      const tensor& src_iter,
+      const tensor& src_iter_c,
+      const tensor& weights_layer,
+      const tensor& weights_iter,
+      const tensor& bias,
+      tensor& dst_layer,
+      tensor& dst_iter,
+      tensor& dst_iter_c,
+      const bool reverse = false,
+      const prop_kind aprop = prop_kind::forward_inference,
+      const float scale = -1.,
+      const int32_t zp = -1,
+      const int weights_scale_mask = -1,
+      const std::vector<float>& weights_scales = scale_t(),
+      const attr_t& attr = attr_t(),
+      const engine& aengine = engine::cpu_engine()) {
+    auto direction = reverse ? rnn_direction::unidirectional_right2left
+                             : rnn_direction::unidirectional_left2right;
+
+    auto src_layer_desc = src_layer.get_desc();
+    auto src_iter_desc = src_iter.get_desc();
+    auto src_iter_c_desc = src_iter_c.get_desc();
+
+    // use any format for weights
+    auto weights_layer_desc = weights_layer.get_desc().to_format_any();
+    auto weights_iter_desc = weights_iter.get_desc().to_format_any();
+
+    attr_t op_attr = attr;
+    if (src_layer.get_data_type() == data_type::u8) {
+      weights_layer_desc = weights_layer_desc.to_type(data_type::s8);
+      weights_iter_desc = weights_iter_desc.to_type(data_type::s8);
+
+      op_attr.set_rnn_data_qparams(scale, zp);
+      op_attr.set_rnn_weights_qparams(weights_scale_mask, weights_scales);
+    }
+
+    auto bias_desc = bias.get_desc();
+    auto dst_layer_desc = dst_layer.get_desc();
+    auto dst_iter_desc = dst_iter.get_desc();
+    auto dst_iter_c_desc = dst_iter_c.get_desc();
+
+    // Use user mode scratchpad
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    auto pd = primitive_desc(
+        {aprop,
+         direction,
+         src_layer_desc,
+         src_iter_desc,
+         src_iter_c_desc,
+         weights_layer_desc,
+         weights_iter_desc,
+         bias_desc,
+         dst_layer_desc,
+         dst_iter_desc,
+         dst_iter_c_desc},
+        op_attr,
+        aengine);
+
+    auto expected_weights_layer =
+        weights_layer.reorder_if_differ_in(pd.weights_layer_desc(), op_attr);
+    auto expected_weights_iter =
+        weights_iter.reorder_if_differ_in(pd.weights_iter_desc(), op_attr);
+    tensor scratchpad(pd.scratchpad_desc());
+
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC_LAYER, src_layer},
+         {DNNL_ARG_SRC_ITER, src_iter},
+         {DNNL_ARG_SRC_ITER_C, src_iter_c},
+         {DNNL_ARG_WEIGHTS_LAYER, expected_weights_layer},
+         {DNNL_ARG_WEIGHTS_ITER, expected_weights_iter},
+         {DNNL_ARG_BIAS, bias},
+         {DNNL_ARG_DST_LAYER, dst_layer},
+         {DNNL_ARG_DST_ITER, dst_iter},
+         {DNNL_ARG_DST_ITER_C, dst_iter_c},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+  }
+
+  static std::tuple<tensor::desc, tensor::desc> expected_weights_desc(
+      const dims& output_sizes,
+      const tensor& src_layer,
+      const tensor& src_iter,
+      const tensor& src_iter_c,
+      const tensor& weights_layer,
+      const tensor& weights_iter,
+      const tensor& bias,
+      const bool reverse = false,
+      const float scale = -1.,
+      const int32_t zp = -1,
+      const int weights_scale_mask = -1,
+      const std::vector<float>& weights_scales = scale_t(),
+      prop_kind aprop = prop_kind::forward_inference,
+      const engine& aengine = engine::cpu_engine()) {
+    auto direction = reverse ? rnn_direction::unidirectional_right2left
+                             : rnn_direction::unidirectional_left2right;
+
+    auto src_layer_desc = src_layer.get_desc();
+    auto src_iter_desc = src_iter.get_desc();
+    auto src_iter_c_desc = src_iter_c.get_desc();
+
+    auto weights_layer_desc = weights_layer.get_desc().to_format_any();
+    auto weights_iter_desc = weights_iter.get_desc().to_format_any();
+
+    attr_t op_attr;
+    if (src_layer.get_data_type() == data_type::u8) {
+      weights_layer_desc = weights_layer_desc.to_type(data_type::s8);
+      weights_iter_desc = weights_iter_desc.to_type(data_type::s8);
+
+      op_attr.set_rnn_data_qparams(scale, zp);
+      op_attr.set_rnn_weights_qparams(weights_scale_mask, weights_scales);
+    }
+
+    auto bias_desc = bias.get_desc();
+    tensor::desc dst_layer_desc(
+        output_sizes, src_layer.get_data_type(), tag::tnc);
+
+    auto pd = primitive_desc(
+        {aprop,
+         direction,
+         src_layer_desc,
+         src_iter_desc,
+         src_iter_c_desc,
+         weights_layer_desc,
+         weights_iter_desc,
+         bias_desc,
+         dst_layer_desc,
+         src_iter_desc,
+         src_iter_c_desc},
+        op_attr,
+        aengine);
+
+    auto expected_weights_layer = pd.weights_layer_desc();
+    auto expected_weights_iter = pd.weights_iter_desc();
+
+    return std::make_tuple(expected_weights_layer, expected_weights_iter);
+  }
+};
+
+struct lstm_forward_training : public dnnl::lstm_forward {
+  using super = dnnl::lstm_forward;
+
+  static primitive_desc prepare(
+      const tensor& src_layer,
+      const tensor& src_iter,
+      const tensor& src_iter_c,
+      const tensor& weights_layer,
+      const tensor& weights_iter,
+      const tensor& bias,
+      tensor& dst_layer,
+      tensor& dst_iter,
+      tensor& dst_iter_c,
+      const bool reverse = false,
+      const attr_t& attr = attr_t(),
+      const engine& aengine = engine::cpu_engine()) {
+    auto direction = reverse ? rnn_direction::unidirectional_right2left
+                             : rnn_direction::unidirectional_left2right;
+
+    auto src_layer_desc = src_layer.get_desc();
+    auto src_iter_desc = src_iter.get_desc();
+    auto src_iter_c_desc = src_iter_c.get_desc();
+    auto bias_desc = bias.get_desc();
+    auto dst_layer_desc = dst_layer.get_desc();
+    auto dst_iter_desc = dst_iter.get_desc();
+    auto dst_iter_c_desc = dst_iter_c.get_desc();
+
+    // use any format for weights
+    auto weights_layer_desc = weights_layer.get_desc().to_format_any();
+    auto weights_iter_desc = weights_iter.get_desc().to_format_any();
+
+    // Use user mode scratchpad
+    auto op_attr = attr;
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    auto pd = primitive_desc(
+        {prop_kind::forward_training,
+         direction,
+         src_layer_desc,
+         src_iter_desc,
+         src_iter_c_desc,
+         weights_layer_desc,
+         weights_iter_desc,
+         bias_desc,
+         dst_layer_desc,
+         dst_iter_desc,
+         dst_iter_c_desc},
+        op_attr,
+        aengine);
+    return pd;
+  }
+
+  static void compute(
+      const primitive_desc& pd,
+      const tensor& src_layer,
+      const tensor& src_iter,
+      const tensor& src_iter_c,
+      const tensor& weights_layer,
+      const tensor& weights_iter,
+      const tensor& bias,
+      const tensor& workspace,
+      tensor& dst_layer,
+      tensor& dst_iter,
+      tensor& dst_iter_c,
+      const bool reverse = false,
+      const prop_kind aprop = prop_kind::forward_training,
+      const engine& aengine = engine::cpu_engine()) {
+    auto expected_weights_layer =
+        weights_layer.reorder_if_differ_in(pd.weights_layer_desc());
+    auto expected_weights_iter =
+        weights_iter.reorder_if_differ_in(pd.weights_iter_desc());
+
+    dst_layer.reinit_if_possible(pd.dst_layer_desc());
+    dst_iter.reinit_if_possible(pd.dst_iter_desc());
+    dst_iter_c.reinit_if_possible(pd.dst_iter_c_desc());
+    tensor scratchpad(pd.scratchpad_desc());
+
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC_LAYER, src_layer},
+         {DNNL_ARG_SRC_ITER, src_iter},
+         {DNNL_ARG_SRC_ITER_C, src_iter_c},
+         {DNNL_ARG_WEIGHTS_LAYER, expected_weights_layer},
+         {DNNL_ARG_WEIGHTS_ITER, expected_weights_iter},
+         {DNNL_ARG_BIAS, bias},
+         {DNNL_ARG_DST_LAYER, dst_layer},
+         {DNNL_ARG_DST_ITER, dst_iter},
+         {DNNL_ARG_DST_ITER_C, dst_iter_c},
+         {DNNL_ARG_WORKSPACE, workspace},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+  }
+
+  static std::tuple<tensor::desc, tensor::desc> expected_weights_desc(
+      const dims& output_sizes,
+      const tensor& src_layer,
+      const tensor& src_iter,
+      const tensor& src_iter_c,
+      const tensor& weights_layer,
+      const tensor& weights_iter,
+      const tensor& bias,
+      const bool reverse = false,
+      prop_kind aprop = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
+    auto direction = reverse ? rnn_direction::unidirectional_right2left
+                             : rnn_direction::unidirectional_left2right;
+
+    auto src_layer_desc = src_layer.get_desc();
+    auto src_iter_desc = src_iter.get_desc();
+    auto src_iter_c_desc = src_iter_c.get_desc();
+
+    auto weights_layer_desc = weights_layer.get_desc().to_format_any();
+    auto weights_iter_desc = weights_iter.get_desc().to_format_any();
+
+    auto bias_desc = bias.get_desc();
+    tensor::desc dst_layer_desc(
+        output_sizes, src_layer.get_data_type(), tag::tnc);
+
+    auto pd = primitive_desc(
+        {aprop,
+         direction,
+         src_layer_desc,
+         src_iter_desc,
+         src_iter_c_desc,
+         weights_layer_desc,
+         weights_iter_desc,
+         bias_desc,
+         dst_layer_desc,
+         src_iter_desc,
+         src_iter_c_desc},
+        aengine);
+
+    auto expected_weights_layer = pd.weights_layer_desc();
+    auto expected_weights_iter = pd.weights_iter_desc();
+
+    return std::make_tuple(expected_weights_layer, expected_weights_iter);
+  }
 };
 
 struct lstm_backward : public dnnl::lstm_backward {
-  static void compute() {}
+  using super = dnnl::lstm_backward;
+
+  static void compute(
+      const dnnl::lstm_forward::primitive_desc& forward_hints,
+      const tensor& src_layer,
+      const tensor& src_iter,
+      const tensor& src_iter_c,
+      const tensor& weights_layer,
+      const tensor& weights_iter,
+      const tensor& bias,
+      const tensor& dst_layer,
+      const tensor& dst_iter,
+      const tensor& dst_iter_c,
+      const tensor& diff_dst_layer,
+      const tensor& diff_dst_iter,
+      const tensor& diff_dst_iter_c,
+      const tensor& workspace,
+      tensor& diff_src_layer,
+      tensor& diff_src_iter,
+      tensor& diff_src_iter_c,
+      tensor& diff_weights_layer,
+      tensor& diff_weights_iter,
+      tensor& diff_bias,
+      const bool reverse = false,
+      const attr_t& attr = attr_t(),
+      const engine& aengine = engine::cpu_engine()) {
+    auto aprop = prop_kind::backward;
+    auto direction = reverse ? rnn_direction::unidirectional_right2left
+                             : rnn_direction::unidirectional_left2right;
+    auto src_layer_desc = src_layer.get_desc();
+    auto src_iter_desc = src_iter.get_desc();
+    auto src_iter_c_desc = src_iter_c.get_desc();
+
+    auto bias_desc = bias.get_desc();
+    auto dst_layer_desc = dst_layer.get_desc();
+    auto dst_iter_desc = dst_iter.get_desc();
+    auto dst_iter_c_desc = dst_iter_c.get_desc();
+
+    // use any format for weights
+    // align weights data type with src
+    auto weights_layer_desc = weights_layer.get_desc().to_format_any();
+    auto weights_iter_desc = weights_iter.get_desc().to_format_any();
+
+    auto diff_src_layer_desc = src_layer_desc.to_type(data_type::f32);
+    auto diff_src_iter_desc = src_iter_desc.to_type(data_type::f32);
+    auto diff_src_iter_c_desc = src_iter_c_desc.to_type(data_type::f32);
+    auto diff_weights_layer_desc = weights_layer_desc.to_type(data_type::f32);
+    auto diff_weights_iter_desc = weights_iter_desc.to_type(data_type::f32);
+    auto diff_bias_desc = bias_desc.to_type(data_type::f32);
+    auto diff_dst_layer_desc = dst_layer_desc.to_type(data_type::f32);
+    auto diff_dst_iter_desc = dst_iter_desc.to_type(data_type::f32);
+    auto diff_dst_iter_c_desc = dst_iter_c_desc.to_type(data_type::f32);
+
+    // Use user mode scratchpad
+    auto op_attr = attr;
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    auto pd = primitive_desc(
+        {aprop,
+         direction,
+         src_layer_desc,
+         src_iter_desc,
+         src_iter_c_desc,
+         weights_layer_desc,
+         weights_iter_desc,
+         bias_desc,
+         dst_layer_desc,
+         dst_iter_desc,
+         dst_iter_c_desc,
+         diff_src_layer_desc,
+         diff_src_iter_desc,
+         diff_src_iter_c_desc,
+         diff_weights_layer_desc,
+         diff_weights_iter_desc,
+         diff_bias_desc,
+         diff_dst_layer_desc,
+         diff_dst_iter_desc,
+         diff_dst_iter_c_desc},
+        op_attr,
+        aengine,
+        forward_hints);
+
+    auto expected_weights_layer =
+        weights_layer.reorder_if_differ_in(pd.weights_layer_desc());
+    auto expected_weights_iter =
+        weights_iter.reorder_if_differ_in(pd.weights_iter_desc());
+
+    diff_src_layer.reinit_if_possible(pd.diff_src_layer_desc());
+    diff_src_iter.reinit_if_possible(pd.diff_src_iter_desc());
+    diff_src_iter_c.reinit_if_possible(pd.diff_src_iter_c_desc());
+
+    // workaround: diff_weights_layer, diff_weights_iter and diff_bias need to
+    // clear before operation begin.
+    tensor expected_diff_weights_layer;
+    expected_diff_weights_layer.zero_init(pd.diff_weights_layer_desc());
+    tensor expected_diff_weights_iter;
+    expected_diff_weights_iter.zero_init(pd.diff_weights_iter_desc());
+    tensor expected_diff_bias;
+    expected_diff_bias.zero_init(pd.diff_bias_desc());
+    tensor scratchpad(pd.scratchpad_desc());
+
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC_LAYER, src_layer},
+         {DNNL_ARG_SRC_ITER, src_iter},
+         {DNNL_ARG_SRC_ITER_C, src_iter_c},
+         {DNNL_ARG_WEIGHTS_LAYER, expected_weights_layer},
+         {DNNL_ARG_WEIGHTS_ITER, expected_weights_iter},
+         {DNNL_ARG_BIAS, bias},
+         {DNNL_ARG_DST_LAYER, dst_layer},
+         {DNNL_ARG_DST_ITER, dst_iter},
+         {DNNL_ARG_DST_ITER_C, dst_iter_c},
+         {DNNL_ARG_DIFF_SRC_LAYER, diff_src_layer},
+         {DNNL_ARG_DIFF_SRC_ITER, diff_src_iter},
+         {DNNL_ARG_DIFF_SRC_ITER_C, diff_src_iter_c},
+         {DNNL_ARG_DIFF_WEIGHTS_LAYER, expected_diff_weights_layer},
+         {DNNL_ARG_DIFF_WEIGHTS_ITER, expected_diff_weights_iter},
+         {DNNL_ARG_DIFF_BIAS, expected_diff_bias},
+         {DNNL_ARG_DIFF_DST_LAYER, diff_dst_layer},
+         {DNNL_ARG_DIFF_DST_ITER, diff_dst_iter},
+         {DNNL_ARG_DIFF_DST_ITER_C, diff_dst_iter_c},
+         {DNNL_ARG_WORKSPACE, workspace},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+
+    diff_weights_layer.feed_from(expected_diff_weights_layer);
+    diff_weights_iter.feed_from(expected_diff_weights_iter);
+    diff_bias.feed_from(expected_diff_bias);
+  }
 };
 
 } // namespace ideep

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -965,7 +965,8 @@ struct matmul_forward : public dnnl::matmul,
     // Prepare tensor of weight zero point
     static auto wei_zero_point = zero_point_t(1);
     const dim wei_zero_point_size = 1;
-    tensor::desc wei_zero_point_desc = {{wei_zero_point_size}, data_type::s32, dims(1, 1)};
+    const dim wei_zero_point_stride = 1;
+    tensor::desc wei_zero_point_desc = {{wei_zero_point_size}, data_type::s32, {wei_zero_point_stride}};
     tensor wei_zero_point_m(wei_zero_point_desc, reinterpret_cast<int*>(wei_zero_point.data()), aengine);
 
     // Post-ops
@@ -1210,7 +1211,8 @@ struct matmul_forward : public dnnl::matmul,
                         : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
     auto& dst_scales_in = IDEEP_DEF_SCALE;
 
-    tensor::desc scales_desc = {{scale_size}, data_type::f32, dims(1, 1)};
+    const dim scale_zp_stride = 1;
+    tensor::desc scales_desc = {{scale_size}, data_type::f32, {scale_zp_stride}};
     tensor scales_m(scales_desc, aengine);
     auto s = reinterpret_cast<float *>(scales_m.get_data_handle());
     for (memory::dim i = 0; i < scale_size; ++i) {
@@ -1219,7 +1221,7 @@ struct matmul_forward : public dnnl::matmul,
 
     // Prepare tensor of src scales
     auto src_scale_size = src_scales_in.size();
-    tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, dims(1, 1)};
+    tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, {scale_zp_stride}};
     tensor src_scales_m(src_scales_desc, reinterpret_cast<float*>(src_scales_in.data()), aengine);
 
     // Prepare tensor of src zero point
@@ -1228,7 +1230,7 @@ struct matmul_forward : public dnnl::matmul,
     const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
     IDEEP_ENFORCE(src_zero_point_size == 1,
                   "DNNL only support 1-dim zero_point");
-    tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, dims(1, 1)};
+    tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, {scale_zp_stride}};
     tensor src_zero_point_m(src_zero_point_desc, reinterpret_cast<int32_t*>(src_zero_point.data()), aengine);
 
     // Reroder src (f32 -> u8)

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -72,16 +72,40 @@ struct matmul_forward : public dnnl::matmul,
     static lowp_kind dummy_lowp_kind = u8s8;
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src, weights, bias, dst,
-          IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
-          IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
-          dst_coeff, sum_coeff, attr, {}, dst_type, dummy_lowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_ZP,
+          IDEEP_EMPTY_ZP,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          {},
+          dst_type,
+          dummy_lowp_kind,
+          aengine);
     } else {
       compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src, weights, bias, dst,
-          IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
-          IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
-          dst_coeff, sum_coeff, attr, {}, dst_type, dummy_lowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_ZP,
+          IDEEP_EMPTY_ZP,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          {},
+          dst_type,
+          dummy_lowp_kind,
+          aengine);
     }
   }
 
@@ -102,10 +126,22 @@ struct matmul_forward : public dnnl::matmul,
     static tensor dummy_bias;
     static lowp_kind dummy_lowp_kind = u8s8;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src, weights, dummy_bias, dst,
-        IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
-        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
-        dst_coeff, sum_coeff, attr, {}, dst_type, dummy_lowp_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        IDEEP_EMPTY_SCALE,
+        IDEEP_EMPTY_SCALE,
+        IDEEP_EMPTY_SCALE,
+        IDEEP_EMPTY_ZP,
+        IDEEP_EMPTY_ZP,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        {},
+        dst_type,
+        dummy_lowp_kind,
+        aengine);
   }
 
   // 2-in-1 compute for fp32 op with bias. Bias is disabled if it is empty.
@@ -122,12 +158,10 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_binary_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src, other, weights, bias, dst,
-          dst_coeff, attr, dst_type, aengine);
+          src, other, weights, bias, dst, dst_coeff, attr, dst_type, aengine);
     } else {
       compute_binary_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src, other, weights, bias, dst,
-          dst_coeff, attr, dst_type, aengine);
+          src, other, weights, bias, dst, dst_coeff, attr, dst_type, aengine);
     }
   }
 
@@ -144,8 +178,15 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_binary_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src, other, weights, dummy_bias, dst,
-        dst_coeff, attr, dst_type, aengine);
+        src,
+        other,
+        weights,
+        dummy_bias,
+        dst,
+        dst_coeff,
+        attr,
+        dst_type,
+        aengine);
   }
 
   // 2-in-1 compute for int8 op with bias. Bias is not used if it is empty.
@@ -171,16 +212,40 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src, weights, bias, dst,
-          src_scales, weights_scales, dst_scales,
-          src_zero_points, dst_zero_points,
-          dst_coeff, sum_coeff, attr, {}, dst_type, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          {},
+          dst_type,
+          alowp_kind,
+          aengine);
     } else {
       compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src, weights, bias, dst,
-          src_scales, weights_scales, dst_scales,
-          src_zero_points, dst_zero_points,
-          dst_coeff, sum_coeff, attr, {}, dst_type, alowp_kind, aengine);
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          {},
+          dst_type,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -206,10 +271,22 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src, weights, dummy_bias, dst,
-        src_scales, weights_scales, dst_scales,
-        src_zero_points, dst_zero_points,
-        dst_coeff, sum_coeff, attr, {},  dst_type, alowp_kind, aengine);
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_points,
+        dst_zero_points,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        {},
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
   // Prepare for fp32 op
@@ -226,11 +303,29 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      do_prepare</*with_bias=*/false>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
-          attr, dst_type, aengine);
+      do_prepare</*with_bias=*/false>(
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          aengine);
     } else {
-      do_prepare</*with_bias=*/true>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
-          attr, dst_type, aengine);
+      do_prepare</*with_bias=*/true>(
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          aengine);
     }
   }
 
@@ -247,8 +342,17 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    do_prepare</*with_bias=*/false>(param, src, weights, dummy_bias, dst, dst_coeff, sum_coeff,
-        attr, dst_type, aengine);
+    do_prepare</*with_bias=*/false>(
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        dst_type,
+        aengine);
   }
 
   // Prepare for int8 op with bias. Bias is not used if it is empty.
@@ -274,24 +378,66 @@ struct matmul_forward : public dnnl::matmul,
     if (is_dynamic) {
       if (bias.is_empty()) {
         do_prepare_dynamic_quant</*with_bias=*/false>(
-            param, src, weights, bias, dst, weights_scales,
-            sum_coeff, attr, data_type::f32, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            weights_scales,
+            sum_coeff,
+            attr,
+            data_type::f32,
+            aengine);
       } else {
         do_prepare_dynamic_quant</*with_bias=*/true>(
-            param, src, weights, bias, dst, weights_scales,
-            sum_coeff, attr, data_type::f32, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            weights_scales,
+            sum_coeff,
+            attr,
+            data_type::f32,
+            aengine);
       }
     } else {
       if (bias.is_empty()) {
         do_prepare_static_quant</*with_bias=*/false>(
-            param, src, weights, bias, dst,
-            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            src_scales,
+            weights_scales,
+            dst_scales,
+            src_zero_points,
+            dst_zero_points,
+            dst_coeff,
+            sum_coeff,
+            attr,
+            dst_type,
+            alowp_kind,
+            aengine);
       } else {
         do_prepare_static_quant</*with_bias=*/true>(
-            param, src, weights, bias, dst,
-            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            src_scales,
+            weights_scales,
+            dst_scales,
+            src_zero_points,
+            dst_zero_points,
+            dst_coeff,
+            sum_coeff,
+            attr,
+            dst_type,
+            alowp_kind,
+            aengine);
       }
     }
   }
@@ -318,13 +464,34 @@ struct matmul_forward : public dnnl::matmul,
     static tensor dummy_bias;
     if (is_dynamic) {
       do_prepare_dynamic_quant</*with_bias=*/false>(
-          param, src, weights, dummy_bias, dst, weights_scales,
-          sum_coeff, attr, data_type::f32, aengine);
+          param,
+          src,
+          weights,
+          dummy_bias,
+          dst,
+          weights_scales,
+          sum_coeff,
+          attr,
+          data_type::f32,
+          aengine);
     } else {
       do_prepare_static_quant</*with_bias=*/false>(
-          param, src, weights, dummy_bias, dst,
-          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-          dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          dummy_bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     }
   }
 
@@ -334,11 +501,12 @@ struct matmul_forward : public dnnl::matmul,
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static inline void compute(const matmul_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst) {
+  static inline void compute(
+      const matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
     if (bias.is_empty()) {
       do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, weights, bias, dst);
@@ -354,10 +522,11 @@ struct matmul_forward : public dnnl::matmul,
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static inline void compute(const matmul_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      tensor& dst) {
+  static inline void compute(
+      const matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst) {
     static tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -381,12 +550,26 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_compute_dynamic_quant</*with_bias=*/false, reorder_weight>(
-          param, src, weights, bias, dst,
-          src_scales, src_zero_points, dst_coeff, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          src_zero_points,
+          dst_coeff,
+          aengine);
     } else {
       do_compute_dynamic_quant</*with_bias=*/true, reorder_weight>(
-          param, src, weights, bias, dst,
-          src_scales, src_zero_points, dst_coeff, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          src_zero_points,
+          dst_coeff,
+          aengine);
     }
   }
 
@@ -407,8 +590,15 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_compute_dynamic_quant</*with_bias=*/false, reorder_weight>(
-        param, src, weights, dummy_bias, dst,
-        src_scales, src_zero_points, dst_coeff, aengine);
+        param,
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        src_scales,
+        src_zero_points,
+        dst_coeff,
+        aengine);
   }
 
   // Deprecated 2-in-1 compute
@@ -431,22 +621,53 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      compute_impl</*with_bias=*/false, /*reorder_src*/true, /*reorder_weight*/true>(
-          src, weights, bias, dst,
-          src_scales, weights_scales, dst_scales,
-          src_zero_points, dst_zero_points,
-          dst_coeff, sum_coeff, attr, {}, dst_type, alowp_kind, aengine);
+      compute_impl<
+          /*with_bias=*/false,
+          /*reorder_src*/ true,
+          /*reorder_weight*/ true>(
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          {},
+          dst_type,
+          alowp_kind,
+          aengine);
     } else {
-      compute_impl</*with_bias=*/true, /*reorder_src*/true, /*reorder_weight*/true>(
-          src, weights, bias, dst,
-          src_scales, weights_scales, dst_scales,
-          src_zero_points, dst_zero_points,
-          dst_coeff, sum_coeff, attr, {}, dst_type, alowp_kind, aengine);
+      compute_impl<
+          /*with_bias=*/true,
+          /*reorder_src*/ true,
+          /*reorder_weight*/ true>(
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          {},
+          dst_type,
+          alowp_kind,
+          aengine);
     }
   }
 
   // Deprecated 2-in-1 compute
-  // Without bias. Zero points are passed explicitly as arguments for quantization
+  // Without bias. Zero points are passed explicitly as arguments for
+  // quantization
   static void compute_v2(
       const tensor& src,
       const tensor& weights,
@@ -463,14 +684,30 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false, /*reorder_src*/true, /*reorder_weight*/true>(
-        src, weights, dummy_bias, dst,
-        src_scales, weights_scales, dst_scales,
-        src_zero_points, dst_zero_points,
-        dst_coeff, sum_coeff, attr, {}, dst_type, alowp_kind, aengine);
+    compute_impl<
+        /*with_bias=*/false,
+        /*reorder_src*/ true,
+        /*reorder_weight*/ true>(
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        src_zero_points,
+        dst_zero_points,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        {},
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
-  // Deprecated 2-in-1 compute. With bias. Set zero points to tensors for quantization.
+  // Deprecated 2-in-1 compute. With bias. Set zero points to tensors for
+  // quantization.
   static void compute(
       const tensor& src,
       const tensor& weights,
@@ -487,13 +724,30 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
-    compute_impl</*with_bias=*/true, /*reorder_src*/true, /*reorder_weight*/true>(
-        src, weights, bias, dst, src_scales, weights_scales, dst_scales,
-        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP, dst_coeff, sum_coeff,
-        attr, bin_post_params, dst_type, alowp_kind, aengine);
+    compute_impl<
+        /*with_bias=*/true,
+        /*reorder_src*/ true,
+        /*reorder_weight*/ true>(
+        src,
+        weights,
+        bias,
+        dst,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        IDEEP_EMPTY_ZP,
+        IDEEP_EMPTY_ZP,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        bin_post_params,
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
-  // Deprecated 2-in-1 compute. Without bias. Set zero points to tensors for quantization.
+  // Deprecated 2-in-1 compute. Without bias. Set zero points to tensors for
+  // quantization.
   static void compute(
       const tensor& src,
       const tensor& weights,
@@ -510,52 +764,111 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false, /*reorder_src*/true, /*reorder_weight*/true>(
-        src, weights, dummy_bias, dst, src_scales, weights_scales, dst_scales,
-        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP, dst_coeff, sum_coeff, attr,
-        bin_post_params, dst_type, alowp_kind, aengine);
+    compute_impl<
+        /*with_bias=*/false,
+        /*reorder_src*/ true,
+        /*reorder_weight*/ true>(
+        src,
+        weights,
+        dummy_bias,
+        dst,
+        src_scales,
+        weights_scales,
+        dst_scales,
+        IDEEP_EMPTY_ZP,
+        IDEEP_EMPTY_ZP,
+        dst_coeff,
+        sum_coeff,
+        attr,
+        bin_post_params,
+        dst_type,
+        alowp_kind,
+        aengine);
   }
 
   // Deprecated. Prepare for int8 op with bias. Bias is not used if it is empty.
   // Static: int8 * int8 -> int8. Dynamic: fp32 * int8 -> fp32
   template <bool is_dynamic = false>
-  static void prepare(matmul_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst,
-                      const float dst_coeff, // default = 1.0f
-                      const float sum_coeff, // for post-op sum, default = 1.0f
-                      const scale_t& src_scales,
-                      const scale_t& weights_scales,
-                      const scale_t& dst_scales,
-                      const zero_point_t& src_zero_points,
-                      const zero_point_t& dst_zero_points,
-                      const attr_t& attr = attr_t(),
-                      const data_type dst_type = data_type::u8,
-                      const lowp_kind alowp_kind = u8s8,
-                      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const float dst_coeff, // default = 1.0f
+      const float sum_coeff, // for post-op sum, default = 1.0f
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_points,
+      const zero_point_t& dst_zero_points,
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::u8,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     if (is_dynamic) {
       if (bias.is_empty()) {
         do_prepare_dynamic_quant</*with_bias=*/false>(
-            param, src, weights, bias, dst, weights_scales,
-            sum_coeff, attr, data_type::f32, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            weights_scales,
+            sum_coeff,
+            attr,
+            data_type::f32,
+            aengine);
       } else {
         do_prepare_dynamic_quant</*with_bias=*/true>(
-            param, src, weights, bias, dst, weights_scales,
-            sum_coeff, attr, data_type::f32, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            weights_scales,
+            sum_coeff,
+            attr,
+            data_type::f32,
+            aengine);
       }
     } else {
       if (bias.is_empty()) {
         do_prepare_static_quant</*with_bias=*/false>(
-            param, src, weights, bias, dst,
-            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            src_scales,
+            weights_scales,
+            dst_scales,
+            src_zero_points,
+            dst_zero_points,
+            dst_coeff,
+            sum_coeff,
+            attr,
+            dst_type,
+            alowp_kind,
+            aengine);
       } else {
         do_prepare_static_quant</*with_bias=*/true>(
-            param, src, weights, bias, dst,
-            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+            param,
+            src,
+            weights,
+            bias,
+            dst,
+            src_scales,
+            weights_scales,
+            dst_scales,
+            src_zero_points,
+            dst_zero_points,
+            dst_coeff,
+            sum_coeff,
+            attr,
+            dst_type,
+            alowp_kind,
+            aengine);
       }
     }
   }
@@ -581,12 +894,26 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_compute_dynamic_quant</*with_bias=*/false>(
-          param, src, weights, bias, dst,
-          src_scales, src_zero_points, dst_coeff, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          src_zero_points,
+          dst_coeff,
+          aengine);
     } else {
       do_compute_dynamic_quant</*with_bias=*/true>(
-          param, src, weights, bias, dst,
-          src_scales, src_zero_points, dst_coeff, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          src_zero_points,
+          dst_coeff,
+          aengine);
     }
   }
 
@@ -597,26 +924,28 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     auto ndims = weights_dims.size();
     auto x_dims = weights_dims;
-    x_dims[ndims-2] = 1;
-    x_dims[ndims-1] = weights_dims[ndims-2];
+    x_dims[ndims - 2] = 1;
+    x_dims[ndims - 1] = weights_dims[ndims - 2];
     auto y_dims = {x_dims[0], weights_dims[1]};
     if (ndims == 3)
-        y_dims = {x_dims[0], x_dims[1], weights_dims[2]};
+      y_dims = {x_dims[0], x_dims[1], weights_dims[2]};
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 
-    IDEEP_ENFORCE(x_dims.size() == weights_dims.size(),
-                  "Invalid dims for data and weights");
+    IDEEP_ENFORCE(
+        x_dims.size() == weights_dims.size(),
+        "Invalid dims for data and weights");
     tensor::desc x_desc(x_dims, x_dtype, ndims == 2 ? tag::ab : tag::abc);
     tensor::desc y_desc(y_dims, y_dtype, ndims == 2 ? tag::ab : tag::abc);
-    tensor::desc weights_desc(weights_dims , dtype, tag::any);
+    tensor::desc weights_desc(weights_dims, dtype, tag::any);
     attr_t attr;
-    // If runtime src zero point is not set here, slow ref kernel will be used for quantization
+    // If runtime src zero point is not set here, slow ref kernel will be used
+    // for quantization
     attr.set_zero_points(DNNL_ARG_SRC, /* mask */ 0, {DNNL_RUNTIME_S32_VAL});
     auto pd = primitive_desc({x_desc, weights_desc, y_desc}, attr, aengine);
     return pd.weights_desc();
   }
 
-private:
+ private:
   // For 2-in-1 compute: prepare + compute
   // Supports fp32, static int8 and dynamic int8
   template <bool with_bias, bool reorder_src, bool reorder_weight>
@@ -642,12 +971,34 @@ private:
         weights.has_scale() ? weights.get_scale() : weights_scales;
     if (!weights_scales_in.empty()) { // for int8
       do_prepare_static_quant<with_bias>(
-          param, src, weights, bias, dst,
-          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-          dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          src_scales,
+          weights_scales,
+          dst_scales,
+          src_zero_points,
+          dst_zero_points,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          alowp_kind,
+          aengine);
     } else {
-      do_prepare<with_bias>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
-                 attr, dst_type, aengine);
+      do_prepare<with_bias>(
+          param,
+          src,
+          weights,
+          bias,
+          dst,
+          dst_coeff,
+          sum_coeff,
+          attr,
+          dst_type,
+          aengine);
     }
     do_compute<with_bias, reorder_src, reorder_weight>(
         param, src, weights, bias, dst, bin_post_params);
@@ -667,8 +1018,17 @@ private:
       const data_type dst_type = data_type::undef,
       const engine& aengine = engine::cpu_engine()) {
     matmul_forward_params param;
-    do_prepare<with_bias>(param, src, weights, bias, dst, dst_coeff, 1.0f,
-        attr, dst_type, aengine);
+    do_prepare<with_bias>(
+        param,
+        src,
+        weights,
+        bias,
+        dst,
+        dst_coeff,
+        1.0f,
+        attr,
+        dst_type,
+        aengine);
     do_compute_binary<with_bias, reorder_src, reorder_weight>(
         param, src, other, weights, bias, dst);
   }
@@ -686,7 +1046,8 @@ private:
       const attr_t& attr = attr_t(),
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
-    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(
+        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
 
     tensor::desc src_desc, weights_desc, bias_desc;
     attr_t& op_attr = param.op_attr;
@@ -709,17 +1070,19 @@ private:
     // introduces *an extra reorder* afterwards. Here we keep the weight format
     // untouched thanks to optimizations for both plain and transposed formats
     // in DNNL.
-    IDEEP_ENFORCE(weights.get_data_type() == data_type::f32 ||
-                  weights.get_data_type() == data_type::bf16,
-                  "Incorrect data type in weights");
-    dst_data_type = src.get_data_type() == data_type::bf16 ?
-                    data_type::bf16 : data_type::f32;
+    IDEEP_ENFORCE(
+        weights.get_data_type() == data_type::f32 ||
+            weights.get_data_type() == data_type::bf16,
+        "Incorrect data type in weights");
+    dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
+                                                           : data_type::f32;
     src_desc = src.get_desc().to_type(dst_data_type);
     weights_desc = weights.get_desc().to_type(dst_data_type);
     if (with_bias) {
-      IDEEP_ENFORCE(bias.get_data_type() == data_type::f32 ||
-                    bias.get_data_type() == data_type::bf16,
-                    "Incorrect data type in bias");
+      IDEEP_ENFORCE(
+          bias.get_data_type() == data_type::f32 ||
+              bias.get_data_type() == data_type::bf16,
+          "Incorrect data type in bias");
       bias_desc = bias.get_desc().to_format_any();
       auto bias_scales = scale_t(1, 1.0 / dst_coeff);
       bias_attr = {utils::tensor_scale_mask(1, false), bias_scales};
@@ -729,10 +1092,9 @@ private:
       op_attr = attr_t::fuse_sum(sum_coeff);
     }
     int scale_size = 1;
-    op_attr.set_output_scales(utils::op_scale_mask(scale_size),
-                              std::vector<float>(1, dst_coeff));
+    op_attr.set_output_scales(
+        utils::op_scale_mask(scale_size), std::vector<float>(1, dst_coeff));
 
-    op_attr.set_fpmath_mode();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     dst_data_type = dst_type == data_type::undef ? dst_data_type : dst_type;
@@ -755,7 +1117,7 @@ private:
       }
     });
     param.primitive = std::move(super(param.pd));
- }
+  }
 
   // For static int8 op (int8 * int8 -> int8)
   template <bool with_bias>
@@ -776,7 +1138,8 @@ private:
       const data_type dst_type = data_type::u8,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
-    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(
+        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
 
     tensor::desc src_desc, weights_desc, bias_desc;
     attr_t& op_attr = param.op_attr;
@@ -794,16 +1157,17 @@ private:
       dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
     }
 
-    auto& weights_scales_in = weights_scales.empty() ? IDEEP_DEF_SCALE : weights_scales;
+    auto& weights_scales_in =
+        weights_scales.empty() ? IDEEP_DEF_SCALE : weights_scales;
 
-    IDEEP_ENFORCE(alowp_kind == u8s8 || alowp_kind == s8s8,
-                  "Unsupported lowp kind");
+    IDEEP_ENFORCE(
+        alowp_kind == u8s8 || alowp_kind == s8s8, "Unsupported lowp kind");
 
     auto src_scales_in = src_scales.empty() ? IDEEP_DEF_SCALE : src_scales;
     auto src_data_type = (alowp_kind == u8s8) ? data_type::u8 : data_type::s8;
-    std::vector<int64_t> src_strides = (ndims == 3) ?
-        std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
-        std::vector<int64_t>({src_dims[1], 1});
+    std::vector<int64_t> src_strides = (ndims == 3)
+        ? std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1})
+        : std::vector<int64_t>({src_dims[1], 1});
     src_desc = tensor::desc(src_dims, src_data_type, tag::any);
     if (src.get_data_type() == data_type::f32) {
       src_attr = {0, src_scales_in};
@@ -812,8 +1176,8 @@ private:
     int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
     weights_desc = weights.get_desc();
     if (weights.get_data_type() == data_type::f32) {
-      weights_attr = {utils::tensor_scale_mask(scale_size, false),
-                      weights_scales_in};
+      weights_attr = {
+          utils::tensor_scale_mask(scale_size, false), weights_scales_in};
     }
 
     // determine dst data type
@@ -828,53 +1192,68 @@ private:
     // fill primitive attr
     scale_t op_scales(scale_size), bias_scales(scale_size);
     dst_scales_in = (dst_scales.empty() || dst_data_type == data_type::f32)
-                        ? IDEEP_DEF_SCALE
-                        : dst_scales;
-    const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
-                                 src_zero_points.empty() ? IDEEP_DEF_ZP : src_zero_points;
+        ? IDEEP_DEF_SCALE
+        : dst_scales;
+    const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point()
+        : src_zero_points.empty()                     ? IDEEP_DEF_ZP
+                                                      : src_zero_points;
     const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
-    const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point() :
-        dst_zero_points.empty() ? IDEEP_DEF_ZP : dst_zero_points;
+    const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point()
+        : dst_zero_points.empty()                     ? IDEEP_DEF_ZP
+                                                      : dst_zero_points;
     const auto dst_zero_point_size = static_cast<dim>(dst_zero_point.size());
-    IDEEP_ENFORCE(src_zero_point_size == 1 && dst_zero_point_size == 1,
-                  "DNNL only support 1-dim zero_point");
-    const auto& wei_zero_point = weights.has_zero_point() ?
-                                 weights.get_zero_point() : IDEEP_DEF_ZP;
+    IDEEP_ENFORCE(
+        src_zero_point_size == 1 && dst_zero_point_size == 1,
+        "DNNL only support 1-dim zero_point");
+    const auto& wei_zero_point =
+        weights.has_zero_point() ? weights.get_zero_point() : IDEEP_DEF_ZP;
 
     if (attr.has_op_kind(kind::sum)) {
-      float sum_scale =
-          sum_coeff * dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+      float sum_scale = sum_coeff * dst_scales_in[0] /
+          (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
       op_attr = attr_t::fuse_sum(sum_scale);
     }
 
-    auto bias_scales_in =
-        bias.has_scale() ? bias.get_scale() : IDEEP_DEF_SCALE;
-    bias_scales_in = bias_scales_in.size() == 1 ?
-        std::vector<float>(scale_size, bias_scales_in[0]) : bias_scales_in;
+    auto bias_scales_in = bias.has_scale() ? bias.get_scale() : IDEEP_DEF_SCALE;
+    bias_scales_in = bias_scales_in.size() == 1
+        ? std::vector<float>(scale_size, bias_scales_in[0])
+        : bias_scales_in;
     for (int i = 0; i < scale_size; i++) {
-      bias_scales[i] = src_scales_in[0] * weights_scales_in[i] / (dst_coeff * bias_scales_in[i]);
-      op_scales[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
+      bias_scales[i] = src_scales_in[0] * weights_scales_in[i] /
+          (dst_coeff * bias_scales_in[i]);
+      op_scales[i] = dst_coeff * dst_scales_in[0] /
+          (src_scales_in[0] * weights_scales_in[i]);
     }
     op_attr.set_output_scales(utils::op_scale_mask(scale_size), op_scales);
-    op_attr.set_zero_points(DNNL_ARG_SRC,
-                            utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
+    op_attr.set_zero_points(
+        DNNL_ARG_SRC,
+        utils::tensor_zp_mask(src_zero_point.size()),
+        src_zero_point);
     if (src.get_data_type() == data_type::f32) {
       // Set zero point for src reorder (fp32 -> int8).
       // First arg should be DNNL_ARG_DST rather than DNNL_ARG_SRC
-      src_attr.set_zero_points(DNNL_ARG_DST,
-                               utils::tensor_zp_mask(src_zero_point.size()),
-                               src_zero_point);
+      src_attr.set_zero_points(
+          DNNL_ARG_DST,
+          utils::tensor_zp_mask(src_zero_point.size()),
+          src_zero_point);
     }
-    op_attr.set_zero_points(DNNL_ARG_WEIGHTS,
-                            utils::tensor_zp_mask(1), zero_point_t(1,wei_zero_point[0]));
+    op_attr.set_zero_points(
+        DNNL_ARG_WEIGHTS,
+        utils::tensor_zp_mask(1),
+        zero_point_t(1, wei_zero_point[0]));
     if (dst_data_type != data_type::f32) {
-      op_attr.set_zero_points(DNNL_ARG_DST,
-                              utils::tensor_zp_mask(dst_zero_point.size()), dst_zero_point);
+      op_attr.set_zero_points(
+          DNNL_ARG_DST,
+          utils::tensor_zp_mask(dst_zero_point.size()),
+          dst_zero_point);
     }
 
     if (with_bias) {
       tag bia_tag = bias.get_dims().size() == 2 ? tag::ab : tag::abc;
-      bias_desc = {bias.get_dims(), data_type::f32, bia_tag}; // Use f32 instead of s32 to improve accuracy
+      bias_desc = {
+          bias.get_dims(),
+          data_type::f32,
+          bia_tag}; // Use f32 instead of s32 to improve accuracy
       if (bias.get_data_type() != data_type::s32) {
         auto ndims = bias.get_dims().size();
         int mask = scale_size > 1 ? 1 << (ndims - 1) : 0;
@@ -904,7 +1283,7 @@ private:
       }
     });
     param.primitive = std::move(super(param.pd));
- }
+  }
 
   // For dynamic int8 op (fp32 * int8 -> fp32)
   template <bool with_bias>
@@ -926,13 +1305,15 @@ private:
      * - Create reorder primitive for src (fp32 -> int8)
      */
 
-    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(
+        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
     if (!param.dq_param_ptr) {
       param.dq_param_ptr = std::make_shared<matmul_forward_dyn_quant_params>();
     }
-    IDEEP_ENFORCE(param.dq_param_ptr, "Failed to allocate memory for parameters");
+    IDEEP_ENFORCE(
+        param.dq_param_ptr, "Failed to allocate memory for parameters");
 
-    tensor::desc &src_desc = param.dq_param_ptr->src_desc;
+    tensor::desc& src_desc = param.dq_param_ptr->src_desc;
     attr_t& op_attr = param.op_attr;
     attr_t src_attr;
 
@@ -940,22 +1321,26 @@ private:
     tensor::dims dst_dims = {src_dims[0], weights.get_dim(1)};
     auto ndims = weights.ndims();
     if (ndims == 3)
-        dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
+      dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
 
     auto& weights_scales_in =
         weights.has_scale() ? weights.get_scale() : weights_scales;
 
     auto src_data_type = data_type::u8;
-    std::vector<int64_t> src_strides = (ndims == 3) ?
-        std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
-        std::vector<int64_t>({src_dims[1], 1});
+    std::vector<int64_t> src_strides = (ndims == 3)
+        ? std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1})
+        : std::vector<int64_t>({src_dims[1], 1});
     src_desc = tensor::desc(src_dims, src_data_type, src_strides);
 
     // Prepare tensor of weight zero point
     static auto wei_zero_point = zero_point_t(1);
     const dim wei_zero_point_size = 1;
-    tensor::desc wei_zero_point_desc = {{wei_zero_point_size}, data_type::s32, {1}};
-    tensor wei_zero_point_m(wei_zero_point_desc, reinterpret_cast<int*>(wei_zero_point.data()), aengine);
+    tensor::desc wei_zero_point_desc = {
+        {wei_zero_point_size}, data_type::s32, dims(1, 1)};
+    tensor wei_zero_point_m(
+        wei_zero_point_desc,
+        reinterpret_cast<int*>(wei_zero_point.data()),
+        aengine);
 
     // Post-ops
     // For dynamic quantization, bias is applied by post-op add
@@ -969,10 +1354,9 @@ private:
     for (int i = 0; i < pops.len(); ++i) {
       // Only sum and eltwise is supported now
       if (kind::sum == pops.kind(i)) {
-        // The parameter sum_coeff is passed in explicitly now due to legacy code.
-        // TO-DO:
-        // Remove the argument 'sum_coeff'.
-        // User should prepare all post-ops in argument 'attr'.
+        // The parameter sum_coeff is passed in explicitly now due to legacy
+        // code. TO-DO: Remove the argument 'sum_coeff'. User should prepare all
+        // post-ops in argument 'attr'.
         new_pops.append_sum(sum_coeff);
       } else if (kind::eltwise == pops.kind(i)) {
         float scale = 1.0, alpha = 1.0, beta = 0.0;
@@ -984,32 +1368,38 @@ private:
     op_attr.set_post_ops(new_pops);
 
     // fill primitive attr
-    op_attr.set_output_scales(utils::op_scale_mask(1/* scale_size */), {DNNL_RUNTIME_F32_VAL});
-    op_attr.set_zero_points(DNNL_ARG_SRC, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
-    op_attr.set_zero_points(DNNL_ARG_WEIGHTS, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    op_attr.set_output_scales(
+        utils::op_scale_mask(1 /* scale_size */), {DNNL_RUNTIME_F32_VAL});
+    op_attr.set_zero_points(
+        DNNL_ARG_SRC, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    op_attr.set_zero_points(
+        DNNL_ARG_WEIGHTS, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     // Src attr for reorder
     src_attr.set_output_scales(utils::op_scale_mask(1), {DNNL_RUNTIME_F32_VAL});
-    src_attr.set_zero_points(DNNL_ARG_DST, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    src_attr.set_zero_points(
+        DNNL_ARG_DST, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
 
     // Dst desc
-    std::vector<int64_t> dst_strides = (ndims == 3) ?
-        std::vector<int64_t>({dst_dims[2]* dst_dims[1], dst_dims[1], 1}) :
-        std::vector<int64_t>({dst_dims[1], 1});
+    std::vector<int64_t> dst_strides = (ndims == 3)
+        ? std::vector<int64_t>({dst_dims[2] * dst_dims[1], dst_dims[1], 1})
+        : std::vector<int64_t>({dst_dims[1], 1});
     tensor::desc dst_desc = tensor::desc(dst_dims, dst_type, dst_strides);
 
     // Create pd and primitive
-    param.pd = primitive_desc({src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
+    param.pd = primitive_desc(
+        {src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
     param.primitive = super(param.pd);
 
     // Create src reorder primitive with runtime scales/zero point
-    auto src_reorder_pd = dnnl::reorder::primitive_desc(aengine, src.get_desc(), aengine, src_desc, src_attr);
+    auto src_reorder_pd = dnnl::reorder::primitive_desc(
+        aengine, src.get_desc(), aengine, src_desc, src_attr);
     param.dq_param_ptr->src_reorder = dnnl::reorder(src_reorder_pd);
 
     param.dq_param_ptr->weight_scales = std::move(weights_scales_in);
     param.dq_param_ptr->wei_zero_point_m = std::move(wei_zero_point_m);
- }
+  }
 
   // For fp32 and static int8 op (int8 * int8 -> int8)
   // Set reorder flags to false if you are sure the memory layout aligns
@@ -1034,32 +1424,33 @@ private:
     auto expected_wei_desc = pd.weights_desc();
     auto expected_dst_desc = pd.dst_desc();
 
-    auto& expected_src = reorder_src ?
-                         src.reorder_if_differ_in(expected_src_desc, src_attr) :
-                         src;
-    auto& expected_weights = reorder_weight ?
-                             weights.reorder_if_differ_in(expected_wei_desc, weights_attr) :
-                             weights;
+    auto& expected_src = reorder_src
+        ? src.reorder_if_differ_in(expected_src_desc, src_attr)
+        : src;
+    auto& expected_weights = reorder_weight
+        ? weights.reorder_if_differ_in(expected_wei_desc, weights_attr)
+        : weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     exec_args args;
     args.insert({DNNL_ARG_SRC, expected_src});
     args.insert({DNNL_ARG_WEIGHTS, expected_weights});
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
-    if (with_bias){
-      auto& expected_bias = reorder_weight ?
-                            bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                            bias;
+    if (with_bias) {
+      auto& expected_bias = reorder_weight
+          ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
+          : bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
     if (reorder_src) {
       tensor expected_dst;
-      if (dst.is_empty() || dst.get_desc() != expected_dst_desc){
-        // If dst buffer are not given by user or user given dst buffer are not under expected format
-        // We need init a new one
+      if (dst.is_empty() || dst.get_desc() != expected_dst_desc) {
+        // If dst buffer are not given by user or user given dst buffer are not
+        // under expected format We need init a new one
         expected_dst.init(expected_dst_desc);
         if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
-          // We need copy the content of given buffer if matmul is fused with sum
+          // We need copy the content of given buffer if matmul is fused with
+          // sum
           expected_dst.feed_from(dst);
         }
       } else {
@@ -1070,14 +1461,13 @@ private:
       for (int i = 0; i < bin_post_params.size(); i++) {
         args.insert(
             {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1,
-            bin_post_params[i].reorder_if_differ_in(expected_dst_desc)});
+             bin_post_params[i].reorder_if_differ_in(expected_dst_desc)});
       }
       primitive.execute(stream::default_stream(), args);
       // reorder back to dst's buffer if needed
-      if (dst.is_empty() ||
-            dst.get_desc() == expected_dst.get_desc() ||
-            !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
-        dst =  expected_dst;
+      if (dst.is_empty() || dst.get_desc() == expected_dst.get_desc() ||
+          !dst.get_desc().has_same_shape_as(expected_dst.get_desc())) {
+        dst = expected_dst;
       } else {
         dst.feed_from(expected_dst);
       }
@@ -1086,7 +1476,7 @@ private:
       for (int i = 0; i < bin_post_params.size(); i++) {
         args.insert(
             {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1,
-            bin_post_params[i]});
+             bin_post_params[i]});
       }
       primitive.execute(stream::default_stream(), args);
     }
@@ -1111,35 +1501,34 @@ private:
     auto expected_wei_desc = pd.weights_desc();
     auto expected_dst_desc = pd.dst_desc();
 
-    auto& expected_src = reorder_src ?
-                         src.reorder_if_differ_in(expected_src_desc) :
-                         src;
-    
-    auto& expected_other = reorder_src ?
-                           other.reorder_if_differ_in(expected_dst_desc) :
-                           other;
-    
-    auto& expected_weights = reorder_weight ?
-                             weights.reorder_if_differ_in(expected_wei_desc) :
-                             weights;
+    auto& expected_src =
+        reorder_src ? src.reorder_if_differ_in(expected_src_desc) : src;
+
+    auto& expected_other =
+        reorder_src ? other.reorder_if_differ_in(expected_dst_desc) : other;
+
+    auto& expected_weights = reorder_weight
+        ? weights.reorder_if_differ_in(expected_wei_desc)
+        : weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     exec_args args;
     args.insert({DNNL_ARG_SRC, expected_src});
     args.insert({DNNL_ARG_WEIGHTS, expected_weights});
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
-    args.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, expected_other});
-    if (with_bias){
-      auto& expected_bias = reorder_weight ?
-                            bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                            bias;
+    args.insert(
+        {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, expected_other});
+    if (with_bias) {
+      auto& expected_bias = reorder_weight
+          ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
+          : bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
     if (reorder_src) {
       tensor expected_dst;
-      if (dst.is_empty() || dst.get_desc() != expected_dst_desc){
-        // If dst buffer are not given by user or user given dst buffer are not under expected format
-        // We need init a new one
+      if (dst.is_empty() || dst.get_desc() != expected_dst_desc) {
+        // If dst buffer are not given by user or user given dst buffer are not
+        // under expected format We need init a new one
         expected_dst.init(expected_dst_desc);
       } else {
         // The format of given dst buffer is expected
@@ -1148,10 +1537,9 @@ private:
       args.insert({DNNL_ARG_DST, expected_dst});
       primitive.execute(stream::default_stream(), args);
       // reorder back to dst's buffer if needed
-      if (dst.is_empty() ||
-            dst.get_desc() == expected_dst.get_desc() ||
-            !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
-        dst =  expected_dst;
+      if (dst.is_empty() || dst.get_desc() == expected_dst.get_desc() ||
+          !dst.get_desc().has_same_shape_as(expected_dst.get_desc())) {
+        dst = expected_dst;
       } else {
         dst.feed_from(expected_dst);
       }
@@ -1176,7 +1564,8 @@ private:
       const zero_point_t& src_zero_points,
       const float dst_coeff = 1.0f,
       const engine& aengine = engine::cpu_engine()) {
-    /* Compute for dynamic quantized linear. This function does the following things:
+    /* Compute for dynamic quantized linear. This function does the following
+     * things:
      * - Get matmul primitive from param
      * - Get reorder primitive for src from param.dq_param_ptr
      * - Prepare tensors of output scales and zero points.
@@ -1184,82 +1573,94 @@ private:
      */
 
     // Get primitive, etc. from param
-    IDEEP_ENFORCE(param.dq_param_ptr, "Parameters for dynamic quantization not found");
+    IDEEP_ENFORCE(
+        param.dq_param_ptr, "Parameters for dynamic quantization not found");
     auto& pd = param.pd;
     auto& primitive = param.primitive;
     auto& weights_attr = param.weights_attr;
     auto& weights_scales_in = param.dq_param_ptr->weight_scales;
     auto& expected_src_desc = param.dq_param_ptr->src_desc;
     auto& wei_zero_point_m = param.dq_param_ptr->wei_zero_point_m;
-    auto &src_reorder = param.dq_param_ptr->src_reorder;
+    auto& src_reorder = param.dq_param_ptr->src_reorder;
 
     // Prepare tensor of output scales
     int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
-    auto src_scales_in =
-        src.has_scale() ? src.get_scale()
-                        : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
+    auto src_scales_in = src.has_scale()
+        ? src.get_scale()
+        : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
     auto& dst_scales_in = IDEEP_DEF_SCALE;
 
-    tensor::desc scales_desc = {{scale_size}, data_type::f32, {1}};
+    tensor::desc scales_desc = {{scale_size}, data_type::f32, dims(1, 1)};
     tensor scales_m(scales_desc, aengine);
-    auto s = reinterpret_cast<float *>(scales_m.get_data_handle());
+    auto s = reinterpret_cast<float*>(scales_m.get_data_handle());
     for (memory::dim i = 0; i < scale_size; ++i) {
-      s[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
+      s[i] = dst_coeff * dst_scales_in[0] /
+          (src_scales_in[0] * weights_scales_in[i]);
     }
 
     // Prepare tensor of src scales
     auto src_scale_size = src_scales_in.size();
-    tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, {1}};
-    tensor src_scales_m(src_scales_desc, reinterpret_cast<float*>(src_scales_in.data()), aengine);
+    tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, dims(1, 1)};
+    tensor src_scales_m(
+        src_scales_desc,
+        reinterpret_cast<float*>(src_scales_in.data()),
+        aengine);
 
     // Prepare tensor of src zero point
-    auto src_zero_point = src.has_zero_point() ? src.get_zero_point() :
-                              src_zero_points.empty() ? IDEEP_DEF_ZP : src_zero_points;
+    auto src_zero_point = src.has_zero_point() ? src.get_zero_point()
+        : src_zero_points.empty()              ? IDEEP_DEF_ZP
+                                               : src_zero_points;
     const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
-    IDEEP_ENFORCE(src_zero_point_size == 1,
-                  "DNNL only support 1-dim zero_point");
-    tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, {1}};
-    tensor src_zero_point_m(src_zero_point_desc, reinterpret_cast<int32_t*>(src_zero_point.data()), aengine);
+    IDEEP_ENFORCE(
+        src_zero_point_size == 1, "DNNL only support 1-dim zero_point");
+    tensor::desc src_zero_point_desc = {
+        {src_zero_point_size}, data_type::s32, dims(1, 1)};
+    tensor src_zero_point_m(
+        src_zero_point_desc,
+        reinterpret_cast<int32_t*>(src_zero_point.data()),
+        aengine);
 
     // Reroder src (f32 -> u8)
     tensor expected_src(expected_src_desc);
-    src_reorder.execute(stream::default_stream(),
-                        {{DNNL_ARG_FROM, src},
-                         {DNNL_ARG_TO, expected_src},
-                         {DNNL_ARG_ATTR_OUTPUT_SCALES, src_scales_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, src_zero_point_m}});
+    src_reorder.execute(
+        stream::default_stream(),
+        {{DNNL_ARG_FROM, src},
+         {DNNL_ARG_TO, expected_src},
+         {DNNL_ARG_ATTR_OUTPUT_SCALES, src_scales_m},
+         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, src_zero_point_m}});
 
     // Check weight desc
-    auto& expected_weights = reorder_weight ?
-                             weights.reorder_if_differ_in(pd.weights_desc(), weights_attr) :
-                             weights;
-    tensor &expected_dst = dst;
+    auto& expected_weights = reorder_weight
+        ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
+        : weights;
+    tensor& expected_dst = dst;
 
     tensor scratchpad(pd.scratchpad_desc());
-    if (with_bias){
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, bias},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    if (with_bias) {
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, bias},
+           {DNNL_ARG_DST, expected_dst},
+           {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, expected_src},
+           {DNNL_ARG_WEIGHTS, expected_weights},
+           {DNNL_ARG_DST, expected_dst},
+           {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
-
 };
 
-}  // namespace ideep
+} // namespace ideep
 
 #endif

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -72,40 +72,18 @@ struct matmul_forward : public dnnl::matmul,
     static lowp_kind dummy_lowp_kind = u8s8;
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst,
-          IDEEP_EMPTY_SCALE,
-          IDEEP_EMPTY_SCALE,
-          IDEEP_EMPTY_SCALE,
-          IDEEP_EMPTY_ZP,
-          IDEEP_EMPTY_ZP,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          {},
-          dst_type,
-          dummy_lowp_kind,
-          aengine);
+          src, weights, bias, dst,
+          IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
+          dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+          dst_type, dummy_lowp_kind, aengine);
     } else {
       compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst,
-          IDEEP_EMPTY_SCALE,
-          IDEEP_EMPTY_SCALE,
-          IDEEP_EMPTY_SCALE,
-          IDEEP_EMPTY_ZP,
-          IDEEP_EMPTY_ZP,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          {},
-          dst_type,
-          dummy_lowp_kind,
-          aengine);
+          src, weights, bias, dst,
+          IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
+          IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
+          dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+          dst_type, dummy_lowp_kind,  aengine);
     }
   }
 
@@ -126,22 +104,11 @@ struct matmul_forward : public dnnl::matmul,
     static tensor dummy_bias;
     static lowp_kind dummy_lowp_kind = u8s8;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src,
-        weights,
-        dummy_bias,
-        dst,
-        IDEEP_EMPTY_SCALE,
-        IDEEP_EMPTY_SCALE,
-        IDEEP_EMPTY_SCALE,
-        IDEEP_EMPTY_ZP,
-        IDEEP_EMPTY_ZP,
-        dst_coeff,
-        sum_coeff,
-        attr,
-        {},
-        dst_type,
-        dummy_lowp_kind,
-        aengine);
+        src, weights, dummy_bias, dst,
+        IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
+        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
+        dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+        dst_type, dummy_lowp_kind, aengine);
   }
 
   // 2-in-1 compute for fp32 op with bias. Bias is disabled if it is empty.
@@ -158,10 +125,12 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_binary_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src, other, weights, bias, dst, dst_coeff, attr, dst_type, aengine);
+          src, other, weights, bias, dst,
+          dst_coeff, attr, dst_type, aengine);
     } else {
       compute_binary_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src, other, weights, bias, dst, dst_coeff, attr, dst_type, aengine);
+          src, other, weights, bias, dst,
+          dst_coeff, attr, dst_type, aengine);
     }
   }
 
@@ -178,15 +147,8 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_binary_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src,
-        other,
-        weights,
-        dummy_bias,
-        dst,
-        dst_coeff,
-        attr,
-        dst_type,
-        aengine);
+        src, other, weights, dummy_bias, dst,
+        dst_coeff, attr, dst_type, aengine);
   }
 
   // 2-in-1 compute for int8 op with bias. Bias is not used if it is empty.
@@ -212,40 +174,18 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_points,
-          dst_zero_points,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          {},
-          dst_type,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst,
+          src_scales, weights_scales, dst_scales,
+          src_zero_points, dst_zero_points,
+          dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+          dst_type, alowp_kind, aengine);
     } else {
       compute_impl</*with_bias=*/true, reorder_src, reorder_weight>(
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_points,
-          dst_zero_points,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          {},
-          dst_type,
-          alowp_kind,
-          aengine);
+          src, weights, bias, dst,
+          src_scales, weights_scales, dst_scales,
+          src_zero_points, dst_zero_points,
+          dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+          dst_type, alowp_kind, aengine);
     }
   }
 
@@ -271,22 +211,11 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     compute_impl</*with_bias=*/false, reorder_src, reorder_weight>(
-        src,
-        weights,
-        dummy_bias,
-        dst,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_points,
-        dst_zero_points,
-        dst_coeff,
-        sum_coeff,
-        attr,
-        {},
-        dst_type,
-        alowp_kind,
-        aengine);
+        src, weights, dummy_bias, dst,
+        src_scales, weights_scales, dst_scales,
+        src_zero_points, dst_zero_points,
+        dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+        dst_type, alowp_kind, aengine);
   }
 
   // Prepare for fp32 op
@@ -303,29 +232,11 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      do_prepare</*with_bias=*/false>(
-          param,
-          src,
-          weights,
-          bias,
-          dst,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          dst_type,
-          aengine);
+      do_prepare</*with_bias=*/false>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
+          attr, dst_type, aengine);
     } else {
-      do_prepare</*with_bias=*/true>(
-          param,
-          src,
-          weights,
-          bias,
-          dst,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          dst_type,
-          aengine);
+      do_prepare</*with_bias=*/true>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
+          attr, dst_type, aengine);
     }
   }
 
@@ -342,17 +253,8 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    do_prepare</*with_bias=*/false>(
-        param,
-        src,
-        weights,
-        dummy_bias,
-        dst,
-        dst_coeff,
-        sum_coeff,
-        attr,
-        dst_type,
-        aengine);
+    do_prepare</*with_bias=*/false>(param, src, weights, dummy_bias, dst, dst_coeff, sum_coeff,
+        attr, dst_type, aengine);
   }
 
   // Prepare for int8 op with bias. Bias is not used if it is empty.
@@ -378,66 +280,24 @@ struct matmul_forward : public dnnl::matmul,
     if (is_dynamic) {
       if (bias.is_empty()) {
         do_prepare_dynamic_quant</*with_bias=*/false>(
-            param,
-            src,
-            weights,
-            bias,
-            dst,
-            weights_scales,
-            sum_coeff,
-            attr,
-            data_type::f32,
-            aengine);
+            param, src, weights, bias, dst, weights_scales,
+            sum_coeff, attr, data_type::f32, aengine);
       } else {
         do_prepare_dynamic_quant</*with_bias=*/true>(
-            param,
-            src,
-            weights,
-            bias,
-            dst,
-            weights_scales,
-            sum_coeff,
-            attr,
-            data_type::f32,
-            aengine);
+            param, src, weights, bias, dst, weights_scales,
+            sum_coeff, attr, data_type::f32, aengine);
       }
     } else {
       if (bias.is_empty()) {
         do_prepare_static_quant</*with_bias=*/false>(
-            param,
-            src,
-            weights,
-            bias,
-            dst,
-            src_scales,
-            weights_scales,
-            dst_scales,
-            src_zero_points,
-            dst_zero_points,
-            dst_coeff,
-            sum_coeff,
-            attr,
-            dst_type,
-            alowp_kind,
-            aengine);
+            param, src, weights, bias, dst,
+            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
       } else {
         do_prepare_static_quant</*with_bias=*/true>(
-            param,
-            src,
-            weights,
-            bias,
-            dst,
-            src_scales,
-            weights_scales,
-            dst_scales,
-            src_zero_points,
-            dst_zero_points,
-            dst_coeff,
-            sum_coeff,
-            attr,
-            dst_type,
-            alowp_kind,
-            aengine);
+            param, src, weights, bias, dst,
+            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
       }
     }
   }
@@ -464,34 +324,13 @@ struct matmul_forward : public dnnl::matmul,
     static tensor dummy_bias;
     if (is_dynamic) {
       do_prepare_dynamic_quant</*with_bias=*/false>(
-          param,
-          src,
-          weights,
-          dummy_bias,
-          dst,
-          weights_scales,
-          sum_coeff,
-          attr,
-          data_type::f32,
-          aengine);
+          param, src, weights, dummy_bias, dst, weights_scales,
+          sum_coeff, attr, data_type::f32, aengine);
     } else {
       do_prepare_static_quant</*with_bias=*/false>(
-          param,
-          src,
-          weights,
-          dummy_bias,
-          dst,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_points,
-          dst_zero_points,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          dst_type,
-          alowp_kind,
-          aengine);
+          param, src, weights, dummy_bias, dst,
+          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+          dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
     }
   }
 
@@ -501,12 +340,11 @@ struct matmul_forward : public dnnl::matmul,
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static inline void compute(
-      const matmul_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst) {
+  static inline void compute(const matmul_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst) {
     if (bias.is_empty()) {
       do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
           param, src, weights, bias, dst);
@@ -522,11 +360,10 @@ struct matmul_forward : public dnnl::matmul,
   // with primitive descriptor. Otherwise, checks are made and reorder
   // may be needed.
   template <bool reorder_src = true, bool reorder_weight = true>
-  static inline void compute(
-      const matmul_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      tensor& dst) {
+  static inline void compute(const matmul_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      tensor& dst) {
     static tensor dummy_bias;
     do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
         param, src, weights, dummy_bias, dst);
@@ -550,26 +387,12 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_compute_dynamic_quant</*with_bias=*/false, reorder_weight>(
-          param,
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          src_zero_points,
-          dst_coeff,
-          aengine);
+          param, src, weights, bias, dst,
+          src_scales, src_zero_points, dst_coeff, aengine);
     } else {
       do_compute_dynamic_quant</*with_bias=*/true, reorder_weight>(
-          param,
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          src_zero_points,
-          dst_coeff,
-          aengine);
+          param, src, weights, bias, dst,
+          src_scales, src_zero_points, dst_coeff, aengine);
     }
   }
 
@@ -590,15 +413,8 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
     do_compute_dynamic_quant</*with_bias=*/false, reorder_weight>(
-        param,
-        src,
-        weights,
-        dummy_bias,
-        dst,
-        src_scales,
-        src_zero_points,
-        dst_coeff,
-        aengine);
+        param, src, weights, dummy_bias, dst,
+        src_scales, src_zero_points, dst_coeff, aengine);
   }
 
   // Deprecated 2-in-1 compute
@@ -621,53 +437,24 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      compute_impl<
-          /*with_bias=*/false,
-          /*reorder_src*/ true,
-          /*reorder_weight*/ true>(
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_points,
-          dst_zero_points,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          {},
-          dst_type,
-          alowp_kind,
-          aengine);
+      compute_impl</*with_bias=*/false, /*reorder_src*/true, /*reorder_weight*/true>(
+          src, weights, bias, dst,
+          src_scales, weights_scales, dst_scales,
+          src_zero_points, dst_zero_points,
+          dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+          dst_type, alowp_kind, aengine);
     } else {
-      compute_impl<
-          /*with_bias=*/true,
-          /*reorder_src*/ true,
-          /*reorder_weight*/ true>(
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_points,
-          dst_zero_points,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          {},
-          dst_type,
-          alowp_kind,
-          aengine);
+      compute_impl</*with_bias=*/true, /*reorder_src*/true, /*reorder_weight*/true>(
+          src, weights, bias, dst,
+          src_scales, weights_scales, dst_scales,
+          src_zero_points, dst_zero_points,
+          dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+          dst_type, alowp_kind, aengine);
     }
   }
 
   // Deprecated 2-in-1 compute
-  // Without bias. Zero points are passed explicitly as arguments for
-  // quantization
+  // Without bias. Zero points are passed explicitly as arguments for quantization
   static void compute_v2(
       const tensor& src,
       const tensor& weights,
@@ -684,30 +471,15 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl<
-        /*with_bias=*/false,
-        /*reorder_src*/ true,
-        /*reorder_weight*/ true>(
-        src,
-        weights,
-        dummy_bias,
-        dst,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        src_zero_points,
-        dst_zero_points,
-        dst_coeff,
-        sum_coeff,
-        attr,
-        {},
-        dst_type,
-        alowp_kind,
-        aengine);
+    compute_impl</*with_bias=*/false, /*reorder_src*/true, /*reorder_weight*/true>(
+        src, weights, dummy_bias, dst,
+        src_scales, weights_scales, dst_scales,
+        src_zero_points, dst_zero_points,
+        dst_coeff, sum_coeff, attr, /*bin_post_params=*/{},
+        dst_type, alowp_kind, aengine);
   }
 
-  // Deprecated 2-in-1 compute. With bias. Set zero points to tensors for
-  // quantization.
+  // Deprecated 2-in-1 compute. With bias. Set zero points to tensors for quantization.
   static void compute(
       const tensor& src,
       const tensor& weights,
@@ -724,30 +496,15 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
-    compute_impl<
-        /*with_bias=*/true,
-        /*reorder_src*/ true,
-        /*reorder_weight*/ true>(
-        src,
-        weights,
-        bias,
-        dst,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        IDEEP_EMPTY_ZP,
-        IDEEP_EMPTY_ZP,
-        dst_coeff,
-        sum_coeff,
-        attr,
-        bin_post_params,
-        dst_type,
-        alowp_kind,
-        aengine);
+    compute_impl</*with_bias=*/true, /*reorder_src*/true, /*reorder_weight*/true>(
+        src, weights, bias, dst,
+        src_scales, weights_scales, dst_scales,
+        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
+        dst_coeff, sum_coeff, attr, bin_post_params,
+        dst_type, alowp_kind, aengine);
   }
 
-  // Deprecated 2-in-1 compute. Without bias. Set zero points to tensors for
-  // quantization.
+  // Deprecated 2-in-1 compute. Without bias. Set zero points to tensors for quantization.
   static void compute(
       const tensor& src,
       const tensor& weights,
@@ -764,111 +521,54 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
     static tensor dummy_bias;
-    compute_impl<
-        /*with_bias=*/false,
-        /*reorder_src*/ true,
-        /*reorder_weight*/ true>(
-        src,
-        weights,
-        dummy_bias,
-        dst,
-        src_scales,
-        weights_scales,
-        dst_scales,
-        IDEEP_EMPTY_ZP,
-        IDEEP_EMPTY_ZP,
-        dst_coeff,
-        sum_coeff,
-        attr,
-        bin_post_params,
-        dst_type,
-        alowp_kind,
-        aengine);
+    compute_impl</*with_bias=*/false, /*reorder_src*/true, /*reorder_weight*/true>(
+        src, weights, dummy_bias, dst,
+        src_scales, weights_scales, dst_scales,
+        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
+        dst_coeff, sum_coeff, attr, bin_post_params,
+        dst_type, alowp_kind, aengine);
   }
 
   // Deprecated. Prepare for int8 op with bias. Bias is not used if it is empty.
   // Static: int8 * int8 -> int8. Dynamic: fp32 * int8 -> fp32
   template <bool is_dynamic = false>
-  static void prepare(
-      matmul_forward_params& param,
-      const tensor& src,
-      const tensor& weights,
-      const tensor& bias,
-      tensor& dst,
-      const float dst_coeff, // default = 1.0f
-      const float sum_coeff, // for post-op sum, default = 1.0f
-      const scale_t& src_scales,
-      const scale_t& weights_scales,
-      const scale_t& dst_scales,
-      const zero_point_t& src_zero_points,
-      const zero_point_t& dst_zero_points,
-      const attr_t& attr = attr_t(),
-      const data_type dst_type = data_type::u8,
-      const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine()) {
+  static void prepare(matmul_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst,
+                      const float dst_coeff, // default = 1.0f
+                      const float sum_coeff, // for post-op sum, default = 1.0f
+                      const scale_t& src_scales,
+                      const scale_t& weights_scales,
+                      const scale_t& dst_scales,
+                      const zero_point_t& src_zero_points,
+                      const zero_point_t& dst_zero_points,
+                      const attr_t& attr = attr_t(),
+                      const data_type dst_type = data_type::u8,
+                      const lowp_kind alowp_kind = u8s8,
+                      const engine& aengine = engine::cpu_engine()) {
     if (is_dynamic) {
       if (bias.is_empty()) {
         do_prepare_dynamic_quant</*with_bias=*/false>(
-            param,
-            src,
-            weights,
-            bias,
-            dst,
-            weights_scales,
-            sum_coeff,
-            attr,
-            data_type::f32,
-            aengine);
+            param, src, weights, bias, dst, weights_scales,
+            sum_coeff, attr, data_type::f32, aengine);
       } else {
         do_prepare_dynamic_quant</*with_bias=*/true>(
-            param,
-            src,
-            weights,
-            bias,
-            dst,
-            weights_scales,
-            sum_coeff,
-            attr,
-            data_type::f32,
-            aengine);
+            param, src, weights, bias, dst, weights_scales,
+            sum_coeff, attr, data_type::f32, aengine);
       }
     } else {
       if (bias.is_empty()) {
         do_prepare_static_quant</*with_bias=*/false>(
-            param,
-            src,
-            weights,
-            bias,
-            dst,
-            src_scales,
-            weights_scales,
-            dst_scales,
-            src_zero_points,
-            dst_zero_points,
-            dst_coeff,
-            sum_coeff,
-            attr,
-            dst_type,
-            alowp_kind,
-            aengine);
+            param, src, weights, bias, dst,
+            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
       } else {
         do_prepare_static_quant</*with_bias=*/true>(
-            param,
-            src,
-            weights,
-            bias,
-            dst,
-            src_scales,
-            weights_scales,
-            dst_scales,
-            src_zero_points,
-            dst_zero_points,
-            dst_coeff,
-            sum_coeff,
-            attr,
-            dst_type,
-            alowp_kind,
-            aengine);
+            param, src, weights, bias, dst,
+            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
       }
     }
   }
@@ -894,26 +594,12 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
       do_compute_dynamic_quant</*with_bias=*/false>(
-          param,
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          src_zero_points,
-          dst_coeff,
-          aengine);
+          param, src, weights, bias, dst,
+          src_scales, src_zero_points, dst_coeff, aengine);
     } else {
       do_compute_dynamic_quant</*with_bias=*/true>(
-          param,
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          src_zero_points,
-          dst_coeff,
-          aengine);
+          param, src, weights, bias, dst,
+          src_scales, src_zero_points, dst_coeff, aengine);
     }
   }
 
@@ -924,21 +610,19 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     auto ndims = weights_dims.size();
     auto x_dims = weights_dims;
-    x_dims[ndims - 2] = 1;
-    x_dims[ndims - 1] = weights_dims[ndims - 2];
+    x_dims[ndims-2] = 1;
+    x_dims[ndims-1] = weights_dims[ndims-2];
     dims y_dims = (ndims == 3) ? dims({x_dims[0], x_dims[1], weights_dims[2]})
                                : dims({x_dims[0], weights_dims[1]});
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 
-    IDEEP_ENFORCE(
-        x_dims.size() == weights_dims.size(),
-        "Invalid dims for data and weights");
+    IDEEP_ENFORCE(x_dims.size() == weights_dims.size(),
+                  "Invalid dims for data and weights");
     tensor::desc x_desc(x_dims, x_dtype, ndims == 2 ? tag::ab : tag::abc);
     tensor::desc y_desc(y_dims, y_dtype, ndims == 2 ? tag::ab : tag::abc);
-    tensor::desc weights_desc(weights_dims, dtype, tag::any);
+    tensor::desc weights_desc(weights_dims , dtype, tag::any);
     attr_t attr;
-    // If runtime src zero point is not set here, slow ref kernel will be used
-    // for quantization
+    // If runtime src zero point is not set here, slow ref kernel will be used for quantization
     attr.set_zero_points(DNNL_ARG_SRC, /* mask */ 0, {DNNL_RUNTIME_S32_VAL});
     auto pd = primitive_desc({x_desc, weights_desc, y_desc}, attr, aengine);
     return pd.weights_desc();
@@ -970,34 +654,12 @@ struct matmul_forward : public dnnl::matmul,
         weights.has_scale() ? weights.get_scale() : weights_scales;
     if (!weights_scales_in.empty()) { // for int8
       do_prepare_static_quant<with_bias>(
-          param,
-          src,
-          weights,
-          bias,
-          dst,
-          src_scales,
-          weights_scales,
-          dst_scales,
-          src_zero_points,
-          dst_zero_points,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          dst_type,
-          alowp_kind,
-          aengine);
+          param, src, weights, bias, dst,
+          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+          dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
     } else {
-      do_prepare<with_bias>(
-          param,
-          src,
-          weights,
-          bias,
-          dst,
-          dst_coeff,
-          sum_coeff,
-          attr,
-          dst_type,
-          aengine);
+      do_prepare<with_bias>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
+                 attr, dst_type, aengine);
     }
     do_compute<with_bias, reorder_src, reorder_weight>(
         param, src, weights, bias, dst, bin_post_params);
@@ -1017,17 +679,8 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::undef,
       const engine& aengine = engine::cpu_engine()) {
     matmul_forward_params param;
-    do_prepare<with_bias>(
-        param,
-        src,
-        weights,
-        bias,
-        dst,
-        dst_coeff,
-        1.0f,
-        attr,
-        dst_type,
-        aengine);
+    do_prepare<with_bias>(param, src, weights, bias, dst, dst_coeff, 1.0f,
+        attr, dst_type, aengine);
     do_compute_binary<with_bias, reorder_src, reorder_weight>(
         param, src, other, weights, bias, dst);
   }
@@ -1045,8 +698,7 @@ struct matmul_forward : public dnnl::matmul,
       const attr_t& attr = attr_t(),
       const data_type dst_type = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
-    IDEEP_ENFORCE(
-        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
 
     tensor::desc src_desc, weights_desc, bias_desc;
     attr_t& op_attr = param.op_attr;
@@ -1069,19 +721,17 @@ struct matmul_forward : public dnnl::matmul,
     // introduces *an extra reorder* afterwards. Here we keep the weight format
     // untouched thanks to optimizations for both plain and transposed formats
     // in DNNL.
-    IDEEP_ENFORCE(
-        weights.get_data_type() == data_type::f32 ||
-            weights.get_data_type() == data_type::bf16,
-        "Incorrect data type in weights");
-    dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
-                                                           : data_type::f32;
+    IDEEP_ENFORCE(weights.get_data_type() == data_type::f32 ||
+                  weights.get_data_type() == data_type::bf16,
+                  "Incorrect data type in weights");
+    dst_data_type = src.get_data_type() == data_type::bf16 ?
+                    data_type::bf16 : data_type::f32;
     src_desc = src.get_desc().to_type(dst_data_type);
     weights_desc = weights.get_desc().to_type(dst_data_type);
     if (with_bias) {
-      IDEEP_ENFORCE(
-          bias.get_data_type() == data_type::f32 ||
-              bias.get_data_type() == data_type::bf16,
-          "Incorrect data type in bias");
+      IDEEP_ENFORCE(bias.get_data_type() == data_type::f32 ||
+                    bias.get_data_type() == data_type::bf16,
+                    "Incorrect data type in bias");
       bias_desc = bias.get_desc().to_format_any();
       auto bias_scales = scale_t(1, 1.0 / dst_coeff);
       bias_attr = {utils::tensor_scale_mask(1, false), bias_scales};
@@ -1091,8 +741,8 @@ struct matmul_forward : public dnnl::matmul,
       op_attr = attr_t::fuse_sum(sum_coeff);
     }
     int scale_size = 1;
-    op_attr.set_output_scales(
-        utils::op_scale_mask(scale_size), std::vector<float>(1, dst_coeff));
+    op_attr.set_output_scales(utils::op_scale_mask(scale_size),
+                              std::vector<float>(1, dst_coeff));
 
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1137,8 +787,7 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::u8,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
-    IDEEP_ENFORCE(
-        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
 
     tensor::desc src_desc, weights_desc, bias_desc;
     attr_t& op_attr = param.op_attr;
@@ -1156,17 +805,16 @@ struct matmul_forward : public dnnl::matmul,
       dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
     }
 
-    auto& weights_scales_in =
-        weights_scales.empty() ? IDEEP_DEF_SCALE : weights_scales;
+    auto& weights_scales_in = weights_scales.empty() ? IDEEP_DEF_SCALE : weights_scales;
 
-    IDEEP_ENFORCE(
-        alowp_kind == u8s8 || alowp_kind == s8s8, "Unsupported lowp kind");
+    IDEEP_ENFORCE(alowp_kind == u8s8 || alowp_kind == s8s8,
+                  "Unsupported lowp kind");
 
     auto src_scales_in = src_scales.empty() ? IDEEP_DEF_SCALE : src_scales;
     auto src_data_type = (alowp_kind == u8s8) ? data_type::u8 : data_type::s8;
-    std::vector<int64_t> src_strides = (ndims == 3)
-        ? std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1})
-        : std::vector<int64_t>({src_dims[1], 1});
+    std::vector<int64_t> src_strides = (ndims == 3) ?
+        std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
+        std::vector<int64_t>({src_dims[1], 1});
     src_desc = tensor::desc(src_dims, src_data_type, tag::any);
     if (src.get_data_type() == data_type::f32) {
       src_attr = {0, src_scales_in};
@@ -1175,8 +823,8 @@ struct matmul_forward : public dnnl::matmul,
     int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
     weights_desc = weights.get_desc();
     if (weights.get_data_type() == data_type::f32) {
-      weights_attr = {
-          utils::tensor_scale_mask(scale_size, false), weights_scales_in};
+      weights_attr = {utils::tensor_scale_mask(scale_size, false),
+                      weights_scales_in};
     }
 
     // determine dst data type
@@ -1193,66 +841,51 @@ struct matmul_forward : public dnnl::matmul,
     dst_scales_in = (dst_scales.empty() || dst_data_type == data_type::f32)
         ? IDEEP_DEF_SCALE
         : dst_scales;
-    const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point()
-        : src_zero_points.empty()                     ? IDEEP_DEF_ZP
-                                                      : src_zero_points;
+    const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
+                                 src_zero_points.empty() ? IDEEP_DEF_ZP : src_zero_points;
     const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
-    const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point()
-        : dst_zero_points.empty()                     ? IDEEP_DEF_ZP
-                                                      : dst_zero_points;
+    const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point() :
+        dst_zero_points.empty() ? IDEEP_DEF_ZP : dst_zero_points;
     const auto dst_zero_point_size = static_cast<dim>(dst_zero_point.size());
-    IDEEP_ENFORCE(
-        src_zero_point_size == 1 && dst_zero_point_size == 1,
-        "DNNL only support 1-dim zero_point");
-    const auto& wei_zero_point =
-        weights.has_zero_point() ? weights.get_zero_point() : IDEEP_DEF_ZP;
+    IDEEP_ENFORCE(src_zero_point_size == 1 && dst_zero_point_size == 1,
+                  "DNNL only support 1-dim zero_point");
+    const auto& wei_zero_point = weights.has_zero_point() ?
+                                 weights.get_zero_point() : IDEEP_DEF_ZP;
 
     if (attr.has_op_kind(kind::sum)) {
-      float sum_scale = sum_coeff * dst_scales_in[0] /
-          (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+      float sum_scale =
+          sum_coeff * dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
       op_attr = attr_t::fuse_sum(sum_scale);
     }
 
-    auto bias_scales_in = bias.has_scale() ? bias.get_scale() : IDEEP_DEF_SCALE;
-    bias_scales_in = bias_scales_in.size() == 1
-        ? std::vector<float>(scale_size, bias_scales_in[0])
-        : bias_scales_in;
+    auto bias_scales_in =
+        bias.has_scale() ? bias.get_scale() : IDEEP_DEF_SCALE;
+    bias_scales_in = bias_scales_in.size() == 1 ?
+        std::vector<float>(scale_size, bias_scales_in[0]) : bias_scales_in;
     for (int i = 0; i < scale_size; i++) {
-      bias_scales[i] = src_scales_in[0] * weights_scales_in[i] /
-          (dst_coeff * bias_scales_in[i]);
-      op_scales[i] = dst_coeff * dst_scales_in[0] /
-          (src_scales_in[0] * weights_scales_in[i]);
+      bias_scales[i] = src_scales_in[0] * weights_scales_in[i] / (dst_coeff * bias_scales_in[i]);
+      op_scales[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
     }
     op_attr.set_output_scales(utils::op_scale_mask(scale_size), op_scales);
-    op_attr.set_zero_points(
-        DNNL_ARG_SRC,
-        utils::tensor_zp_mask(src_zero_point.size()),
-        src_zero_point);
+    op_attr.set_zero_points(DNNL_ARG_SRC,
+                            utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
     if (src.get_data_type() == data_type::f32) {
       // Set zero point for src reorder (fp32 -> int8).
       // First arg should be DNNL_ARG_DST rather than DNNL_ARG_SRC
-      src_attr.set_zero_points(
-          DNNL_ARG_DST,
-          utils::tensor_zp_mask(src_zero_point.size()),
-          src_zero_point);
+      src_attr.set_zero_points(DNNL_ARG_DST,
+                               utils::tensor_zp_mask(src_zero_point.size()),
+                               src_zero_point);
     }
-    op_attr.set_zero_points(
-        DNNL_ARG_WEIGHTS,
-        utils::tensor_zp_mask(1),
-        zero_point_t(1, wei_zero_point[0]));
+    op_attr.set_zero_points(DNNL_ARG_WEIGHTS,
+                            utils::tensor_zp_mask(1), zero_point_t(1,wei_zero_point[0]));
     if (dst_data_type != data_type::f32) {
-      op_attr.set_zero_points(
-          DNNL_ARG_DST,
-          utils::tensor_zp_mask(dst_zero_point.size()),
-          dst_zero_point);
+      op_attr.set_zero_points(DNNL_ARG_DST,
+                              utils::tensor_zp_mask(dst_zero_point.size()), dst_zero_point);
     }
 
     if (with_bias) {
       tag bia_tag = bias.get_dims().size() == 2 ? tag::ab : tag::abc;
-      bias_desc = {
-          bias.get_dims(),
-          data_type::f32,
-          bia_tag}; // Use f32 instead of s32 to improve accuracy
+      bias_desc = {bias.get_dims(), data_type::f32, bia_tag}; // Use f32 instead of s32 to improve accuracy
       if (bias.get_data_type() != data_type::s32) {
         auto ndims = bias.get_dims().size();
         int mask = scale_size > 1 ? 1 << (ndims - 1) : 0;
@@ -1304,15 +937,13 @@ struct matmul_forward : public dnnl::matmul,
      * - Create reorder primitive for src (fp32 -> int8)
      */
 
-    IDEEP_ENFORCE(
-        src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
     if (!param.dq_param_ptr) {
       param.dq_param_ptr = std::make_shared<matmul_forward_dyn_quant_params>();
     }
-    IDEEP_ENFORCE(
-        param.dq_param_ptr, "Failed to allocate memory for parameters");
+    IDEEP_ENFORCE(param.dq_param_ptr, "Failed to allocate memory for parameters");
 
-    tensor::desc& src_desc = param.dq_param_ptr->src_desc;
+    tensor::desc &src_desc = param.dq_param_ptr->src_desc;
     attr_t& op_attr = param.op_attr;
     attr_t src_attr;
 
@@ -1326,20 +957,16 @@ struct matmul_forward : public dnnl::matmul,
         weights.has_scale() ? weights.get_scale() : weights_scales;
 
     auto src_data_type = data_type::u8;
-    std::vector<int64_t> src_strides = (ndims == 3)
-        ? std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1})
-        : std::vector<int64_t>({src_dims[1], 1});
+    std::vector<int64_t> src_strides = (ndims == 3) ?
+        std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
+        std::vector<int64_t>({src_dims[1], 1});
     src_desc = tensor::desc(src_dims, src_data_type, src_strides);
 
     // Prepare tensor of weight zero point
     static auto wei_zero_point = zero_point_t(1);
     const dim wei_zero_point_size = 1;
-    tensor::desc wei_zero_point_desc = {
-        {wei_zero_point_size}, data_type::s32, dims(1, 1)};
-    tensor wei_zero_point_m(
-        wei_zero_point_desc,
-        reinterpret_cast<int*>(wei_zero_point.data()),
-        aengine);
+    tensor::desc wei_zero_point_desc = {{wei_zero_point_size}, data_type::s32, dims(1, 1)};
+    tensor wei_zero_point_m(wei_zero_point_desc, reinterpret_cast<int*>(wei_zero_point.data()), aengine);
 
     // Post-ops
     // For dynamic quantization, bias is applied by post-op add
@@ -1353,9 +980,10 @@ struct matmul_forward : public dnnl::matmul,
     for (int i = 0; i < pops.len(); ++i) {
       // Only sum and eltwise is supported now
       if (kind::sum == pops.kind(i)) {
-        // The parameter sum_coeff is passed in explicitly now due to legacy
-        // code. TO-DO: Remove the argument 'sum_coeff'. User should prepare all
-        // post-ops in argument 'attr'.
+        // The parameter sum_coeff is passed in explicitly now due to legacy code.
+        // TO-DO:
+        // Remove the argument 'sum_coeff'.
+        // User should prepare all post-ops in argument 'attr'.
         new_pops.append_sum(sum_coeff);
       } else if (kind::eltwise == pops.kind(i)) {
         float scale = 1.0, alpha = 1.0, beta = 0.0;
@@ -1367,33 +995,27 @@ struct matmul_forward : public dnnl::matmul,
     op_attr.set_post_ops(new_pops);
 
     // fill primitive attr
-    op_attr.set_output_scales(
-        utils::op_scale_mask(1 /* scale_size */), {DNNL_RUNTIME_F32_VAL});
-    op_attr.set_zero_points(
-        DNNL_ARG_SRC, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
-    op_attr.set_zero_points(
-        DNNL_ARG_WEIGHTS, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    op_attr.set_output_scales(utils::op_scale_mask(1/* scale_size */), {DNNL_RUNTIME_F32_VAL});
+    op_attr.set_zero_points(DNNL_ARG_SRC, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    op_attr.set_zero_points(DNNL_ARG_WEIGHTS, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     // Src attr for reorder
     src_attr.set_output_scales(utils::op_scale_mask(1), {DNNL_RUNTIME_F32_VAL});
-    src_attr.set_zero_points(
-        DNNL_ARG_DST, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    src_attr.set_zero_points(DNNL_ARG_DST, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
 
     // Dst desc
-    std::vector<int64_t> dst_strides = (ndims == 3)
-        ? std::vector<int64_t>({dst_dims[2] * dst_dims[1], dst_dims[1], 1})
-        : std::vector<int64_t>({dst_dims[1], 1});
+    std::vector<int64_t> dst_strides = (ndims == 3) ?
+        std::vector<int64_t>({dst_dims[2]* dst_dims[1], dst_dims[1], 1}) :
+        std::vector<int64_t>({dst_dims[1], 1});
     tensor::desc dst_desc = tensor::desc(dst_dims, dst_type, dst_strides);
 
     // Create pd and primitive
-    param.pd = primitive_desc(
-        {src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
+    param.pd = primitive_desc({src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
     param.primitive = super(param.pd);
 
     // Create src reorder primitive with runtime scales/zero point
-    auto src_reorder_pd = dnnl::reorder::primitive_desc(
-        aengine, src.get_desc(), aengine, src_desc, src_attr);
+    auto src_reorder_pd = dnnl::reorder::primitive_desc(aengine, src.get_desc(), aengine, src_desc, src_attr);
     param.dq_param_ptr->src_reorder = dnnl::reorder(src_reorder_pd);
 
     param.dq_param_ptr->weight_scales = std::move(weights_scales_in);
@@ -1423,12 +1045,12 @@ struct matmul_forward : public dnnl::matmul,
     auto expected_wei_desc = pd.weights_desc();
     auto expected_dst_desc = pd.dst_desc();
 
-    auto& expected_src = reorder_src
-        ? src.reorder_if_differ_in(expected_src_desc, src_attr)
-        : src;
-    auto& expected_weights = reorder_weight
-        ? weights.reorder_if_differ_in(expected_wei_desc, weights_attr)
-        : weights;
+    auto& expected_src = reorder_src ?
+                         src.reorder_if_differ_in(expected_src_desc, src_attr) :
+                         src;
+    auto& expected_weights = reorder_weight ?
+                             weights.reorder_if_differ_in(expected_wei_desc, weights_attr) :
+                             weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     exec_args args;
@@ -1443,13 +1065,12 @@ struct matmul_forward : public dnnl::matmul,
     }
     if (reorder_src) {
       tensor expected_dst;
-      if (dst.is_empty() || dst.get_desc() != expected_dst_desc) {
-        // If dst buffer are not given by user or user given dst buffer are not
-        // under expected format We need init a new one
+      if (dst.is_empty() || dst.get_desc() != expected_dst_desc){
+        // If dst buffer are not given by user or user given dst buffer are not under expected format
+        // We need init a new one
         expected_dst.init(expected_dst_desc);
         if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
-          // We need copy the content of given buffer if matmul is fused with
-          // sum
+          // We need copy the content of given buffer if matmul is fused with sum
           expected_dst.feed_from(dst);
         }
       } else {
@@ -1500,15 +1121,17 @@ struct matmul_forward : public dnnl::matmul,
     auto expected_wei_desc = pd.weights_desc();
     auto expected_dst_desc = pd.dst_desc();
 
-    auto& expected_src =
-        reorder_src ? src.reorder_if_differ_in(expected_src_desc) : src;
-
-    auto& expected_other =
-        reorder_src ? other.reorder_if_differ_in(expected_dst_desc) : other;
-
-    auto& expected_weights = reorder_weight
-        ? weights.reorder_if_differ_in(expected_wei_desc)
-        : weights;
+    auto& expected_src = reorder_src ?
+                         src.reorder_if_differ_in(expected_src_desc) :
+                         src;
+    
+    auto& expected_other = reorder_src ?
+                           other.reorder_if_differ_in(expected_dst_desc) :
+                           other;
+    
+    auto& expected_weights = reorder_weight ?
+                             weights.reorder_if_differ_in(expected_wei_desc) :
+                             weights;
     tensor scratchpad(pd.scratchpad_desc());
 
     exec_args args;
@@ -1525,9 +1148,9 @@ struct matmul_forward : public dnnl::matmul,
     }
     if (reorder_src) {
       tensor expected_dst;
-      if (dst.is_empty() || dst.get_desc() != expected_dst_desc) {
-        // If dst buffer are not given by user or user given dst buffer are not
-        // under expected format We need init a new one
+      if (dst.is_empty() || dst.get_desc() != expected_dst_desc){
+        // If dst buffer are not given by user or user given dst buffer are not under expected format
+        // We need init a new one
         expected_dst.init(expected_dst_desc);
       } else {
         // The format of given dst buffer is expected
@@ -1563,8 +1186,7 @@ struct matmul_forward : public dnnl::matmul,
       const zero_point_t& src_zero_points,
       const float dst_coeff = 1.0f,
       const engine& aengine = engine::cpu_engine()) {
-    /* Compute for dynamic quantized linear. This function does the following
-     * things:
+    /* Compute for dynamic quantized linear. This function does the following things:
      * - Get matmul primitive from param
      * - Get reorder primitive for src from param.dq_param_ptr
      * - Prepare tensors of output scales and zero points.
@@ -1572,95 +1194,82 @@ struct matmul_forward : public dnnl::matmul,
      */
 
     // Get primitive, etc. from param
-    IDEEP_ENFORCE(
-        param.dq_param_ptr, "Parameters for dynamic quantization not found");
+    IDEEP_ENFORCE(param.dq_param_ptr, "Parameters for dynamic quantization not found");
     auto& pd = param.pd;
     auto& primitive = param.primitive;
     auto& weights_attr = param.weights_attr;
     auto& weights_scales_in = param.dq_param_ptr->weight_scales;
     auto& expected_src_desc = param.dq_param_ptr->src_desc;
     auto& wei_zero_point_m = param.dq_param_ptr->wei_zero_point_m;
-    auto& src_reorder = param.dq_param_ptr->src_reorder;
+    auto &src_reorder = param.dq_param_ptr->src_reorder;
 
     // Prepare tensor of output scales
     int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
-    auto src_scales_in = src.has_scale()
-        ? src.get_scale()
-        : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
+    auto src_scales_in =
+        src.has_scale() ? src.get_scale()
+                        : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
     auto& dst_scales_in = IDEEP_DEF_SCALE;
 
     tensor::desc scales_desc = {{scale_size}, data_type::f32, dims(1, 1)};
     tensor scales_m(scales_desc, aengine);
-    auto s = reinterpret_cast<float*>(scales_m.get_data_handle());
+    auto s = reinterpret_cast<float *>(scales_m.get_data_handle());
     for (memory::dim i = 0; i < scale_size; ++i) {
-      s[i] = dst_coeff * dst_scales_in[0] /
-          (src_scales_in[0] * weights_scales_in[i]);
+      s[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
     }
 
     // Prepare tensor of src scales
     auto src_scale_size = src_scales_in.size();
-    tensor::desc src_scales_desc = {
-        {src_scale_size}, data_type::f32, dims(1, 1)};
-    tensor src_scales_m(
-        src_scales_desc,
-        reinterpret_cast<float*>(src_scales_in.data()),
-        aengine);
+    tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, dims(1, 1)};
+    tensor src_scales_m(src_scales_desc, reinterpret_cast<float*>(src_scales_in.data()), aengine);
 
     // Prepare tensor of src zero point
-    auto src_zero_point = src.has_zero_point() ? src.get_zero_point()
-        : src_zero_points.empty()              ? IDEEP_DEF_ZP
-                                               : src_zero_points;
+    auto src_zero_point = src.has_zero_point() ? src.get_zero_point() :
+                              src_zero_points.empty() ? IDEEP_DEF_ZP : src_zero_points;
     const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
-    IDEEP_ENFORCE(
-        src_zero_point_size == 1, "DNNL only support 1-dim zero_point");
-    tensor::desc src_zero_point_desc = {
-        {src_zero_point_size}, data_type::s32, dims(1, 1)};
-    tensor src_zero_point_m(
-        src_zero_point_desc,
-        reinterpret_cast<int32_t*>(src_zero_point.data()),
-        aengine);
+    IDEEP_ENFORCE(src_zero_point_size == 1,
+                  "DNNL only support 1-dim zero_point");
+    tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, dims(1, 1)};
+    tensor src_zero_point_m(src_zero_point_desc, reinterpret_cast<int32_t*>(src_zero_point.data()), aengine);
 
     // Reroder src (f32 -> u8)
     tensor expected_src(expected_src_desc);
-    src_reorder.execute(
-        stream::default_stream(),
-        {{DNNL_ARG_FROM, src},
-         {DNNL_ARG_TO, expected_src},
-         {DNNL_ARG_ATTR_OUTPUT_SCALES, src_scales_m},
-         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, src_zero_point_m}});
+    src_reorder.execute(stream::default_stream(),
+                        {{DNNL_ARG_FROM, src},
+                        {DNNL_ARG_TO, expected_src},
+                        {DNNL_ARG_ATTR_OUTPUT_SCALES, src_scales_m},
+                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, src_zero_point_m}});
 
     // Check weight desc
-    auto& expected_weights = reorder_weight
-        ? weights.reorder_if_differ_in(pd.weights_desc(), weights_attr)
-        : weights;
-    tensor& expected_dst = dst;
+    auto& expected_weights = reorder_weight ?
+                             weights.reorder_if_differ_in(pd.weights_desc(), weights_attr) :
+                             weights;
+    tensor &expected_dst = dst;
 
     tensor scratchpad(pd.scratchpad_desc());
-    if (with_bias) {
-      primitive.execute(
-          stream::default_stream(),
-          {{DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_WEIGHTS, expected_weights},
-           {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, bias},
-           {DNNL_ARG_DST, expected_dst},
-           {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
-           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    if (with_bias){
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                        {DNNL_ARG_WEIGHTS, expected_weights},
+                        {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, bias},
+                        {DNNL_ARG_DST, expected_dst},
+                        {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
+                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
+                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     } else {
-      primitive.execute(
-          stream::default_stream(),
-          {{DNNL_ARG_SRC, expected_src},
-           {DNNL_ARG_WEIGHTS, expected_weights},
-           {DNNL_ARG_DST, expected_dst},
-           {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
-           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-           {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                        {DNNL_ARG_WEIGHTS, expected_weights},
+                        {DNNL_ARG_DST, expected_dst},
+                        {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
+                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
+                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
   }
+
 };
 
-} // namespace ideep
+}  // namespace ideep
 
 #endif

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -926,9 +926,8 @@ struct matmul_forward : public dnnl::matmul,
     auto x_dims = weights_dims;
     x_dims[ndims - 2] = 1;
     x_dims[ndims - 1] = weights_dims[ndims - 2];
-    auto y_dims = {x_dims[0], weights_dims[1]};
-    if (ndims == 3)
-      y_dims = {x_dims[0], x_dims[1], weights_dims[2]};
+    dims y_dims = (ndims == 3) ? dims({x_dims[0], x_dims[1], weights_dims[2]})
+                               : dims({x_dims[0], weights_dims[1]});
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 
     IDEEP_ENFORCE(
@@ -1600,7 +1599,8 @@ struct matmul_forward : public dnnl::matmul,
 
     // Prepare tensor of src scales
     auto src_scale_size = src_scales_in.size();
-    tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, dims(1, 1)};
+    tensor::desc src_scales_desc = {
+        {src_scale_size}, data_type::f32, dims(1, 1)};
     tensor src_scales_m(
         src_scales_desc,
         reinterpret_cast<float*>(src_scales_in.data()),


### PR DESCRIPTION
## Description
Merge conv/deconv/inner_product/matmul.hpp in public ideep and IPEX's ideep.
Update lstm.hpp
Format these files with clang-format.

## Changes:
**Conv:**
- API compatibility
  - IPEX's conv param has a member called 'pd_use_threads'.  Set in `do_prepare()`, only used outside ideep. Sol: keep it.
  - IPEX's conv param has a member 'op_attr'. Sol: keep it.
  - IPEX has a compute API which takes conv param and primitive. Sol: keep it.
- Merge expected_weights_desc()
  - In IPEX 'channels_last' is a template parameter but in ideep 'use_channels_last' is a function argument. Sol: use 'is_channels_last' as a template parameter.
  - In IPEX, channels last for conv1d is considered. Sol: keep it.
  - In IPEX, different dummy src sizes are used. Sol: keep it.
  - In IPEX, set scratchpad mode to 'user' and set fpmath mode Sol: keep scratchpad mode and define operator = of attr_t as deep copy
- Merge get_primitive_desc()
  - In public ideep, the 'keep_format' parameter is removed. Sol: remove it.
  - In IPEX, both src and weight are checked for layout. Conv1d is considered. Sol: keep it.
- Merge compute_dispatch()
- Merge do_prepare() (FP32 only)
  - In IPEX, set scratchpad mode to user and set fpmath mode. Sol: keep scratchpad mode and define operator = of attr_t as deep copy. Fpmath mode to be set by framework
- Merge do_compute() (FP32 only)
  - IPEX has a more complex way of dealing with dst (init / reinit / feed from). Sol: Keep it.
  - IPEX has a different way of reordering weight. Sol: Keep it as in public ideep.
- Merge convolution_backward_data / weights
  - Add 'attr' to arg list of `compute()` (for fpmath mode setting)

**Deconv:**
- API compatibility with IPEX (OK)
- Merge expected_weights_desc()
  - In IPEX 'channels_last' is a template parameter. Sol: add template argument 'is_channels_last'.
  - The returned desc is transposed in ideep but not in IPEX. Both versions are used in FWK now. Public used by Caffe2 and quantization in PyTorch. Sol: Keep the logic in public ideep. Need to change IPEX.
- Merge get_primitive_desc()
- Merge do_prepare() and do_compute()
  - IPEX does not call set_fpmath_mode. Sol: align with other ops (set by framework).
- Merge convolution_transpose_backward_data / weights
  - In IPEX, define a new diff_weight tensor for computing. Sol: Keep it as in IPEX.
  - Add 'attr' to arg list of `compute()` (for fpmath mode setting)

**Inner_product:**
- API compatibility
  - IPEX still uses the old API with scales. Sol: add deprecated API.
- Merge expected_weights_desc
  - Batch size of X is different. Use IPEX's. Sol: use value in IPEX
- Merge compute_impl / do_prepare / do_compute
  - fpmath mode to be set by framework
- Merge backward data / weights
  - Add 'attr' to arg list of `compute()` (for fpmath mode setting)

**Matmul:**
- API compatibility
  - IPEX still uses the old API with scales. Sol: Keep the old API.
  - IPEX has a new param 'bin_post_params' (binary post-op arguments). Sol: Merge it to public ideep
- Merge expected_weights_desc
  - Public ideep sets runtime zero point. Is it OK for fp32? Sol: Keep it for now. Need tests.
- Merge compute impl
  - IPEX has 'bin_post_params' (binary post-op arguments). Sol: Merge it to public ideep 
  - fpmath mode to be set by framework
  - IPEX considers higher dimensional tensors (> 3d). Sol: Merge it to public ideep (for fp32 only)

**Attributes**
- Constructors
  - Define copy constructor
  - Construct by fpmath mode (by @blzheng)
- Set fpmath mode (by @blzheng)
- Define operator=
  - deep copy of `attr_t` to keep the `const` semantics where we often do `auto op_attr = attr;`.