### PR TITLE
Bug fixes about conv and matmul

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -20,8 +20,10 @@ struct attr_t : public dnnl::primitive_attr {
     set_output_scales(mask, scales);
   }
 
-  attr_t(dnnl_fpmath_mode_t mode) {
-    set_fpmath_mode(mode);
+  attr_t(dnnl_fpmath_mode_t fpmath_mode,
+         dnnl::scratchpad_mode sp_mode = dnnl::scratchpad_mode::user) {
+    set_fpmath_mode(fpmath_mode);
+    set_scratchpad_mode(sp_mode);
   }
 
   attr_t& set_fpmath_mode(dnnl_fpmath_mode_t mode) {
@@ -47,6 +49,11 @@ struct attr_t : public dnnl::primitive_attr {
     zero_point_t zero_points;
     get_zero_points(arg, mask, zero_points);
     return std::make_pair(zero_points, mask);
+  }
+
+  void get_zero_points(
+          int arg, int &mask, std::vector<int32_t> &zero_points) const {
+      dnnl::primitive_attr::get_zero_points(arg, mask, zero_points);
   }
 
   // Helper factory

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -774,17 +774,16 @@ struct convolution_forward
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::convolution_direct,
                       prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
                       const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
     if (bias.is_empty()) {
       compute_dispatch</*with_bias=*/false, true, true>(
           src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     } else {
       compute_dispatch</*with_bias=*/true, true, true>(
           src, weights, bias, dst_dims, dst, strides, dilates,
-          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
     }
   }
 
@@ -805,13 +804,12 @@ struct convolution_forward
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::convolution_direct,
                       prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
                       const engine& aengine = engine::cpu_engine()) {
     // Consider fp32 only for IPEX
     static tensor dummy_bias;
     compute_dispatch</*with_bias=*/false, true, true>(
         src, weights, dummy_bias, dst_dims, dst, strides, dilates,
-        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+        padding_l, padding_r, groups, attr, aalgorithm, aprop_kind, aengine);
   }
 
   // DEPRECATED


### PR DESCRIPTION
Bug fixes about conv and matmul
- Update constructor of `attr_t` so that sccratchpad mode is set to user automatically. This aligns with the logic in IPEX now.
- For some deprecated APIs of conv, they are only used for fp32 in IPEX. So, we remove unnecessary arguments related to quantization
- For matmul, do not try to reorder post op parameters (tensors) since they may have different shapes than the output.