### PR TITLE
Add hardsigmoid fusion together with oneDNN update

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -252,6 +252,18 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
+  static attr_t fuse_hardsigmoid() {
+    constexpr float scale = 1.0f;
+    constexpr float alpha = 1.0f / 6.0f;
+    constexpr float beta = 1.0f / 2.0f;
+
+    attr_t attr;
+    post_ops po;
+    po.append_eltwise(scale, algorithm::eltwise_hardsigmoid, alpha, beta);
+    attr.set_post_ops(po);
+    return attr;
+  }
+
   static attr_t fuse_binary(algorithm alg, memory::desc src_desc) {
     attr_t attr;
     post_ops po;


### PR DESCRIPTION
This PR aims to add the hardsigmoid fusion support in ideep attribute, which is originally from IPEX/Ideep by Chunyuan. We defer this as the last one to be converged into this branch as this hardsigmoid fusion need recent llga/oneDNN support, which requires to update llga/oneDNN version accordingly. However, the new version of llga changes two of its interfaces which requires stock pytorch to update related code firstly. So we'd put this PR as the last one for ideep_converge which can then be branched out without this commit for current stock branch.

Details of the changing:
- Added hardsigmoid in attribute.hpp
`include/ideep/attributes.hpp`

- Update mkldnn version (llga) to be the same as latest IPEX
`mkl-dnn`