### PR TITLE
Sync with recent changes in IPEX's ideep

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -286,6 +286,11 @@ struct attr_t : public dnnl::primitive_attr {
     return false;
   }
 
+  bool has_post_op() const {
+    auto po = get_post_ops();
+    return po.len() > 0;
+  }
+
   std::tuple<kind, float, float, float, algorithm> get_params(int index) const {
     auto po = get_post_ops();
     IDEEP_ENFORCE(index < po.len(), "post_ops index is out of range");

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -748,6 +748,9 @@ struct matmul_forward : public dnnl::matmul,
 
     dst_data_type = dst_type == data_type::undef ? dst_data_type : dst_type;
     tensor::desc dst_desc = tensor::desc(dst_dims, dst_data_type, tag::any);
+    if (!dst.is_empty()) {
+      dst_desc = dst.get_desc().to_type(dst_data_type);
+    }
     auto key = utils::create_key(
         src_desc,
         weights_desc,
@@ -897,6 +900,9 @@ struct matmul_forward : public dnnl::matmul,
 
     dst_data_type = dst_type == data_type::undef ? dst_data_type : dst_type;
     tensor::desc dst_desc = tensor::desc(dst_dims, dst_data_type, tag::any);
+    if (!dst.is_empty()) {
+      dst_desc = dst.get_desc().to_type(dst_data_type);
+    }
     auto key = utils::create_key(
         src_desc,
         weights_desc,
@@ -1010,6 +1016,9 @@ struct matmul_forward : public dnnl::matmul,
         std::vector<int64_t>({dst_dims[2]* dst_dims[1], dst_dims[1], 1}) :
         std::vector<int64_t>({dst_dims[1], 1});
     tensor::desc dst_desc = tensor::desc(dst_dims, dst_type, dst_strides);
+    if (!dst.is_empty()) {
+      dst_desc = dst.get_desc().to_type(dst_type);
+    }
 
     // Create pd and primitive
     param.pd = primitive_desc({src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);


### PR DESCRIPTION
Sync with recent changes in IPEX's ideep
- mamtul.hpp: changes from https://github.com/intel-innersource/frameworks.ai.pytorch.ipex-cpu/pull/992
- attributes.hpp: changes from https://github.com/intel-innersource/frameworks.ai.pytorch.ipex-cpu/pull/1060