### PR TITLE
Bug fix: bias tensor is out of its scope, etc.

### DIFF
--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1339,16 +1339,16 @@ struct convolution_forward
     kernel_size.push_back(dims_in[ndims - 1]);
     if (src_dims.empty()) {
       // Construct a dummy case. Shape from resnet50 model.
-      x_dims.push_back(32);
+      x_dims.push_back(1);
       x_dims.push_back(ic);
-      y_dims.push_back(32);
+      y_dims.push_back(1);
       y_dims.push_back(oc);
-      x_dims.push_back(14 * kernel_size[0]);
+      x_dims.push_back(4 * kernel_size[0]);
       if (4 == src_size) {
-        x_dims.push_back(14 * kernel_size[1]);
+        x_dims.push_back(8 * kernel_size[1]);
       } else if (5 == src_size) {
-        x_dims.push_back(14 * kernel_size[1]);
-        x_dims.push_back(14 * kernel_size[2]);
+        x_dims.push_back(8 * kernel_size[1]);
+        x_dims.push_back(8 * kernel_size[2]);
       }
     } else {
       // Use the real data
@@ -1806,10 +1806,10 @@ private:
     args.insert({DNNL_ARG_WEIGHTS, expected_weights});
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
     args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point});
+    auto& expected_bias = (with_bias && reorder_weight) ?
+        bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr) :
+        bias;
     if (with_bias) {
-      auto& expected_bias = reorder_weight ?
-          bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr) :
-          bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
 

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -1146,10 +1146,10 @@ struct matmul_forward : public dnnl::matmul,
     args.insert({DNNL_ARG_SRC, expected_src});
     args.insert({DNNL_ARG_WEIGHTS, expected_weights});
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
+    auto& expected_bias = (with_bias && reorder_weight)
+        ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
+        : bias;
     if (with_bias) {
-      auto& expected_bias = reorder_weight
-          ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
-          : bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
     // Do not reorder these params. They may have different shapes as dst
@@ -1225,10 +1225,10 @@ struct matmul_forward : public dnnl::matmul,
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
     args.insert(
         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, expected_other});
+    auto& expected_bias = (with_bias && reorder_weight)
+        ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
+        : bias;
     if (with_bias) {
-      auto& expected_bias = reorder_weight
-          ? bias.reorder_if_differ_in(pd.bias_desc(), bias_attr)
-          : bias;
       args.insert({DNNL_ARG_BIAS, expected_bias});
     }
     if (reorder_src) {


### PR DESCRIPTION
To fix bugs found by PyTorch UT. The issues listed below have a 10~20% chance of causing UT failure.
- Bias tensor is defined in an `if` statement and inserted to primitive exec args (`std::unordered_map`). So, it is out of scope when calling primitive execution. Now move it outside `if` statement.
- In `convolution::weight_expected_desc`, IPEX uses a shape from ResNet50 as a guess of input shape if not specified. In this converged version of ideep, we use the values from IPEX. Looks like it may cause UT failure for grouped quantized convolution. So here I reverted them to old values.
  - I have no idea why the shape would cause errors. It may be related to selection of weight layouts and onednn kernels, but weight should be reordered before computation if descriptors mismatch.
  - This change will not cause regression of correctness in IPEX. For performance, we need tests to validate. If performance regression is found for IPEX, we may need two versions of such input shape for conv weight prepacking.

Validation: UTs of stock & internal PyTorch and IPEX passed.